### PR TITLE
Add initial automated combat test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,14 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "devDependencies": {
     "dotenv": "^16.4.7",
-    "vite": "^6.2.2"
+    "vite": "^6.2.2",
+    "vitest": "^1.5.0",
+    "jsdom": "^24.0.0"
   },
   "dependencies": {
     "marked": "^15.0.12",

--- a/tests/combat.test.js
+++ b/tests/combat.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import * as globals from '../src/globals.js';
+import Game from '../src/game.js';
+import Hero from '../src/hero.js';
+import Enemy from '../src/enemy.js';
+import Statistics from '../src/statistics.js';
+import SkillTree from '../src/skillTree.js';
+import CrystalShop from '../src/crystalShop.js';
+
+// Mock all UI modules to avoid DOM requirements
+vi.mock('../src/ui/ui.js', () => new Proxy({}, { get: () => vi.fn() }));
+vi.mock('../src/ui/statsAndAttributesUi.js', () => ({ updateStatsAndAttributesUI: vi.fn() }));
+vi.mock('../src/ui/questUi.js', () => ({ updateQuestsUI: vi.fn() }));
+vi.mock('../src/ui/bossUi.js', () => ({ updateBossUI: vi.fn(), selectBoss: vi.fn() }));
+
+vi.mock('../src/dataManager.js', () => ({ DataManager: class { saveGame() {} startSessionMonitor() {} loadGame() { return Promise.resolve(null); } } }));
+
+describe('combat', () => {
+  beforeEach(() => {
+    globals.game = new Game();
+    globals.hero = new Hero();
+    globals.skillTree = new SkillTree();
+    globals.statistics = new Statistics();
+    globals.crystalShop = new CrystalShop();
+    globals.inventory = {
+      addMaterial: vi.fn(),
+      createItem: vi.fn(() => ({})),
+      addItemToInventory: vi.fn(),
+      getRandomMaterial: vi.fn(() => ({ id: 'mat', icon: 'M', name: 'Mat' })),
+    };
+    globals.dataManager = { saveGame: vi.fn() };
+
+    globals.game.currentRegionId = 'forest';
+    globals.game.stage = 1;
+    globals.game.currentEnemy = new Enemy(1);
+
+    // ensure massive damage for instant kills
+    globals.hero.stats.damage = 10000;
+
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('increments enemy kill count after defeating 10 enemies', async () => {
+    for (let i = 0; i < 10; i++) {
+      globals.game.damageEnemy(10000);
+      await vi.advanceTimersByTimeAsync(600);
+    }
+    expect(globals.statistics.enemiesKilled.total).toBe(10);
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest and jsdom dev dependencies
- configure vitest for jsdom
- implement a combat test validating that defeating 10 enemies increments the kill counter

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/vitest: Forbidden - 403)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68622e5ec4a48331ae963face9901d69