### PR TITLE
Add Druid and Mage classes

### DIFF
--- a/src/constants/skills.js
+++ b/src/constants/skills.js
@@ -4,6 +4,8 @@ import { VAMPIRE_SKILLS } from '../constants/skills/vampireSkills.js';
 import { PALADIN_SKILLS } from '../constants/skills/paladinSkills.js';
 import { BERSERKER_SKILLS } from '../constants/skills/berserkerSkills.js';
 import { ELEMENTALIST_SKILLS } from '../constants/skills/elementalistSkills.js';
+import { DRUID_SKILLS } from '../constants/skills/druidSkills.js';
+import { MAGE_SKILLS } from '../constants/skills/mageSkills.js';
 
 export const CLASS_PATHS = {
   WARRIOR: {
@@ -91,6 +93,34 @@ export const CLASS_PATHS = {
     requiredLevel: () => 110,
     crystalCost: () => 75,
   },
+  DRUID: {
+    name: () => 'Druid',
+    enabled: () => true,
+    avatar: () => 'druid-avatar.jpg',
+    baseStats: () => ({
+      lifeRegenPercent: 20,
+      lifePercent: 20,
+      coldDamagePercent: 30,
+      earthDamagePercent: 30,
+    }),
+    description: () => 'Wielder of nature magic and animal allies',
+    requiredLevel: () => 130,
+    crystalCost: () => 90,
+  },
+  MAGE: {
+    name: () => 'Mage',
+    enabled: () => true,
+    avatar: () => 'mage-avatar.jpg',
+    baseStats: () => ({
+      manaPercent: 50,
+      manaRegen: 1,
+      elementalDamagePercent: 20,
+      wisdom: 40,
+    }),
+    description: () => 'Master of arcane spells and destructive magic',
+    requiredLevel: () => 150,
+    crystalCost: () => 110,
+  },
 };
 
 export const SKILL_TREES = {
@@ -105,4 +135,8 @@ export const SKILL_TREES = {
   BERSERKER: BERSERKER_SKILLS,
 
   ELEMENTALIST: ELEMENTALIST_SKILLS,
+
+  DRUID: DRUID_SKILLS,
+
+  MAGE: MAGE_SKILLS,
 };

--- a/src/constants/skills/druidSkills.js
+++ b/src/constants/skills/druidSkills.js
@@ -1,0 +1,204 @@
+import { DEFAULT_MAX_SKILL_LEVEL, SKILL_LEVEL_TIERS } from '../../skillTree.js';
+
+// Druid skills
+export const DRUID_SKILLS = {
+  // Tier 1 Skills
+  barkSkin: {
+    id: 'barkSkin',
+    name: () => 'Bark Skin',
+    type: () => 'toggle',
+    manaCost: (level) => 1 + level * 0.1,
+    requiredLevel: () => SKILL_LEVEL_TIERS[0],
+    icon: () => 'bark-skin',
+    description: () => 'Increases armor while active.',
+    maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
+    effect: (level) => ({
+      armorPercent: level * 2,
+      lifeRegen: level * 0.05,
+    }),
+  },
+  naturalAffinity: {
+    id: 'naturalAffinity',
+    name: () => 'Natural Affinity',
+    type: () => 'passive',
+    requiredLevel: () => SKILL_LEVEL_TIERS[0],
+    icon: () => 'leaf',
+    description: () => 'Increases vitality and life regeneration.',
+    maxLevel: () => 200,
+    effect: (level) => ({
+      vitality: level * 1,
+      lifePercent: level * 0.1,
+      lifeRegen: level * 0.1,
+    }),
+  },
+
+  // Tier 10 Skills
+  rejuvenation: {
+    id: 'rejuvenation',
+    name: () => 'Rejuvenation',
+    type: () => 'buff',
+    manaCost: (level) => 5 + level * 0.2,
+    cooldown: (level) => 20000,
+    duration: (level) => 10000 + level * 500,
+    requiredLevel: () => SKILL_LEVEL_TIERS[1],
+    icon: () => 'rejuvenation',
+    description: () => 'Restores life over time.',
+    maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
+    effect: (level) => ({
+      lifeRegenPercent: level * 0.5,
+    }),
+  },
+  entanglingRoots: {
+    id: 'entanglingRoots',
+    name: () => 'Entangling Roots',
+    type: () => 'instant',
+    manaCost: (level) => 4 + level * 0.3,
+    cooldown: (level) => 8000,
+    requiredLevel: () => SKILL_LEVEL_TIERS[1],
+    icon: () => 'roots',
+    description: () => 'Deals earth damage and slows enemies.',
+    maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
+    effect: (level) => ({
+      earthDamagePercent: level * 5,
+      attackSpeed: level * -0.005,
+    }),
+  },
+
+  // Tier 25 Skills
+  animalCompanion: {
+    id: 'animalCompanion',
+    name: () => 'Animal Companion',
+    type: () => 'toggle',
+    manaCost: (level) => 5 + level * 0.2,
+    requiredLevel: () => SKILL_LEVEL_TIERS[2],
+    icon: () => 'companion',
+    description: () => 'Summons a beast to aid you, increasing damage.',
+    maxLevel: () => 200,
+    effect: (level) => ({
+      damagePercent: level * 3,
+      lifePerHit: level * 0.5,
+    }),
+  },
+  naturalGrowth: {
+    id: 'naturalGrowth',
+    name: () => 'Natural Growth',
+    type: () => 'passive',
+    requiredLevel: () => SKILL_LEVEL_TIERS[2],
+    icon: () => 'growth',
+    description: () => 'Increases life and life regeneration.',
+    maxLevel: () => 200,
+    effect: (level) => ({
+      lifePercent: level * 0.5,
+      lifeRegen: level * 0.2,
+    }),
+  },
+
+  // Tier 50 Skills
+  hurricane: {
+    id: 'hurricane',
+    name: () => 'Hurricane',
+    type: () => 'instant',
+    manaCost: (level) => 8 + level * 0.4,
+    cooldown: (level) => 6000,
+    requiredLevel: () => SKILL_LEVEL_TIERS[3],
+    icon: () => 'hurricane',
+    description: () => 'Calls forth fierce winds to damage enemies.',
+    maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
+    effect: (level) => ({
+      airDamagePercent: level * 10,
+    }),
+  },
+  stoneform: {
+    id: 'stoneform',
+    name: () => 'Stoneform',
+    type: () => 'buff',
+    manaCost: (level) => 10 + level * 0.5,
+    cooldown: (level) => 45000,
+    duration: (level) => 20000,
+    requiredLevel: () => SKILL_LEVEL_TIERS[3],
+    icon: () => 'stoneform',
+    description: () => 'Hardens your skin, boosting armor and resistance.',
+    maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
+    effect: (level) => ({
+      armorPercent: level * 5,
+      earthDamagePercent: level * 2,
+    }),
+  },
+
+  // Tier 75 Skills
+  spiritLink: {
+    id: 'spiritLink',
+    name: () => 'Spirit Link',
+    type: () => 'buff',
+    manaCost: (level) => 15 + level * 0.5,
+    cooldown: (level) => 60000,
+    duration: (level) => 30000,
+    requiredLevel: () => SKILL_LEVEL_TIERS[4],
+    icon: () => 'spirit-link',
+    description: () => 'Increases life steal and mana gain.',
+    maxLevel: () => 300,
+    effect: (level) => ({
+      lifeSteal: level * 0.01,
+      manaPerHit: level * 0.2,
+    }),
+  },
+  moonfury: {
+    id: 'moonfury',
+    name: () => 'Moonfury',
+    type: () => 'passive',
+    requiredLevel: () => SKILL_LEVEL_TIERS[4],
+    icon: () => 'moon',
+    description: () => 'Empowers you under the moon, boosting elemental damage.',
+    maxLevel: () => 300,
+    effect: (level) => ({
+      coldDamagePercent: level * 2,
+      airDamagePercent: level * 2,
+    }),
+  },
+
+  // Tier 100 Skills
+  earthsEmbrace: {
+    id: 'earthsEmbrace',
+    name: () => "Earth's Embrace",
+    type: () => 'toggle',
+    manaCost: (level) => 4 + level * 0.3,
+    requiredLevel: () => SKILL_LEVEL_TIERS[5],
+    icon: () => 'embrace',
+    description: () => 'Embrace the earth for defense and regeneration.',
+    maxLevel: () => 500,
+    effect: (level) => ({
+      armorPercent: level * 4,
+      lifeRegenPercent: level * 0.5,
+    }),
+  },
+  wrathOfNature: {
+    id: 'wrathOfNature',
+    name: () => 'Wrath of Nature',
+    type: () => 'passive',
+    requiredLevel: () => SKILL_LEVEL_TIERS[5],
+    icon: () => 'wrath',
+    description: () => 'Nature fights with you, increasing all stats.',
+    maxLevel: () => 500,
+    effect: (level) => ({
+      damagePercent: level * 1,
+      vitalityPercent: level * 1,
+      elementalDamagePercent: level * 1,
+    }),
+  },
+
+  // Tier 200 Skills
+  avatarOfNature: {
+    id: 'avatarOfNature',
+    name: () => 'Avatar of Nature',
+    type: () => 'passive',
+    requiredLevel: () => SKILL_LEVEL_TIERS[6],
+    icon: () => 'avatar-of-nature',
+    description: () => 'Become one with nature, greatly increasing attributes.',
+    maxLevel: () => 100,
+    effect: (level) => ({
+      vitalityPercent: level * 3,
+      damagePercent: level * 2,
+      lifePercent: level * 2,
+    }),
+  },
+};

--- a/src/constants/skills/mageSkills.js
+++ b/src/constants/skills/mageSkills.js
@@ -1,0 +1,202 @@
+import { DEFAULT_MAX_SKILL_LEVEL, SKILL_LEVEL_TIERS } from '../../skillTree.js';
+
+// Mage skills
+export const MAGE_SKILLS = {
+  // Tier 1 Skills
+  magicMissile: {
+    id: 'magicMissile',
+    name: () => 'Magic Missile',
+    type: () => 'instant',
+    manaCost: (level) => 2 + level * 0.2,
+    cooldown: (level) => 2500,
+    requiredLevel: () => SKILL_LEVEL_TIERS[0],
+    icon: () => 'missile',
+    description: () => 'Launches a missile of arcane energy.',
+    maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
+    effect: (level) => ({
+      damagePercent: level * 4,
+    }),
+  },
+  arcaneIntellect: {
+    id: 'arcaneIntellect',
+    name: () => 'Arcane Intellect',
+    type: () => 'passive',
+    requiredLevel: () => SKILL_LEVEL_TIERS[0],
+    icon: () => 'intellect',
+    description: () => 'Increases mana and wisdom.',
+    maxLevel: () => 300,
+    effect: (level) => ({
+      manaPercent: level * 1,
+      wisdomPercent: level * 1,
+    }),
+  },
+
+  // Tier 10 Skills
+  frostBolt: {
+    id: 'frostBolt',
+    name: () => 'Frost Bolt',
+    type: () => 'instant',
+    manaCost: (level) => 3 + level * 0.2,
+    cooldown: (level) => 3000,
+    requiredLevel: () => SKILL_LEVEL_TIERS[1],
+    icon: () => 'frost-bolt',
+    description: () => 'Fires a bolt of frost at the enemy.',
+    maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
+    effect: (level) => ({
+      coldDamagePercent: level * 6,
+    }),
+  },
+  fireBlast: {
+    id: 'fireBlast',
+    name: () => 'Fire Blast',
+    type: () => 'instant',
+    manaCost: (level) => 4 + level * 0.2,
+    cooldown: (level) => 4000,
+    requiredLevel: () => SKILL_LEVEL_TIERS[1],
+    icon: () => 'fire-blast',
+    description: () => 'Blasts the target with fire.',
+    maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
+    effect: (level) => ({
+      fireDamagePercent: level * 6,
+    }),
+  },
+
+  // Tier 25 Skills
+  teleport: {
+    id: 'teleport',
+    name: () => 'Teleport',
+    type: () => 'instant',
+    manaCost: (level) => 15 + level * 1,
+    cooldown: (level) => 30000,
+    requiredLevel: () => SKILL_LEVEL_TIERS[2],
+    icon: () => 'teleport',
+    description: () => 'Instantly move to a nearby location.',
+    maxLevel: () => 100,
+    effect: () => ({}) ,
+  },
+  manaShield: {
+    id: 'manaShield',
+    name: () => 'Mana Shield',
+    type: () => 'buff',
+    manaCost: (level) => 8 + level * 0.5,
+    cooldown: (level) => 20000,
+    duration: (level) => 12000 + level * 500,
+    requiredLevel: () => SKILL_LEVEL_TIERS[2],
+    icon: () => 'mana-shield',
+    description: () => 'Absorbs damage using mana.',
+    maxLevel: () => 200,
+    effect: (level) => ({
+      armorPercent: level * 4,
+    }),
+  },
+
+  // Tier 50 Skills
+  iceStorm: {
+    id: 'iceStorm',
+    name: () => 'Ice Storm',
+    type: () => 'buff',
+    manaCost: (level) => 15 + level * 0.6,
+    cooldown: (level) => 40000,
+    duration: (level) => 20000,
+    requiredLevel: () => SKILL_LEVEL_TIERS[3],
+    icon: () => 'ice-storm',
+    description: () => 'Summons a storm of ice around you.',
+    maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
+    effect: (level) => ({
+      coldDamagePercent: level * 8,
+    }),
+  },
+  arcaneFocus: {
+    id: 'arcaneFocus',
+    name: () => 'Arcane Focus',
+    type: () => 'passive',
+    requiredLevel: () => SKILL_LEVEL_TIERS[3],
+    icon: () => 'focus',
+    description: () => 'Improves spell damage and hit rate.',
+    maxLevel: () => 500,
+    effect: (level) => ({
+      damagePercent: level * 1,
+      attackRatingPercent: level * 4,
+    }),
+  },
+
+  // Tier 75 Skills
+  pyroclasm: {
+    id: 'pyroclasm',
+    name: () => 'Pyroclasm',
+    type: () => 'buff',
+    manaCost: (level) => 20 + level * 0.6,
+    cooldown: (level) => 45000,
+    duration: (level) => 30000,
+    requiredLevel: () => SKILL_LEVEL_TIERS[4],
+    icon: () => 'pyroclasm',
+    description: () => 'Engulfs the area in flames.',
+    maxLevel: () => 300,
+    effect: (level) => ({
+      fireDamagePercent: level * 10,
+    }),
+  },
+  timeWarp: {
+    id: 'timeWarp',
+    name: () => 'Time Warp',
+    type: () => 'buff',
+    manaCost: (level) => 25 + level * 0.7,
+    cooldown: (level) => 60000,
+    duration: (level) => 15000,
+    requiredLevel: () => SKILL_LEVEL_TIERS[4],
+    icon: () => 'time-warp',
+    description: () => 'Greatly increases attack speed for a short time.',
+    maxLevel: () => 300,
+    effect: (level) => ({
+      attackSpeedPercent: level * 0.01,
+    }),
+  },
+
+  // Tier 100 Skills
+  arcanePower: {
+    id: 'arcanePower',
+    name: () => 'Arcane Power',
+    type: () => 'toggle',
+    manaCost: (level) => 5 + level * 0.3,
+    requiredLevel: () => SKILL_LEVEL_TIERS[5],
+    icon: () => 'arcane-power',
+    description: () => 'Unleash arcane power, increasing spell damage.',
+    maxLevel: () => 600,
+    effect: (level) => ({
+      elementalDamagePercent: level * 3,
+    }),
+  },
+  summonElemental: {
+    id: 'summonElemental',
+    name: () => 'Summon Elemental',
+    type: () => 'buff',
+    manaCost: (level) => 30 + level * 0.8,
+    cooldown: (level) => 80000,
+    duration: (level) => 30000,
+    requiredLevel: () => SKILL_LEVEL_TIERS[5],
+    icon: () => 'summon-elemental',
+    description: () => 'Summons an elemental ally.',
+    maxLevel: () => 500,
+    effect: (level) => ({
+      fireDamagePercent: level * 2,
+      coldDamagePercent: level * 2,
+      airDamagePercent: level * 2,
+    }),
+  },
+
+  // Tier 200 Skills
+  archmage: {
+    id: 'archmage',
+    name: () => 'Archmage',
+    type: () => 'passive',
+    requiredLevel: () => SKILL_LEVEL_TIERS[6],
+    icon: () => 'archmage',
+    description: () => 'Mastery of all magical arts.',
+    maxLevel: () => 100,
+    effect: (level) => ({
+      wisdomPercent: level * 4,
+      elementalDamagePercent: level * 2,
+      manaPercent: level * 2,
+    }),
+  },
+};


### PR DESCRIPTION
## Summary
- add druid and mage class skills
- register druid and mage in the constants skill tree

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686979fb04d08331a794e18408eb4ab3