### PR TITLE
Add upgrade material salvage option

### DIFF
--- a/src/css/inventory.css
+++ b/src/css/inventory.css
@@ -663,7 +663,8 @@
   user-select: none;
 }
 
-.auto-salvage-toggle+.toggle-btn {
+.auto-salvage-toggle+.toggle-btn,
+.salvage-material-toggle+.toggle-btn {
   display: inline-block;
   width: 48px;
   height: 26px;
@@ -678,6 +679,7 @@
 }
 
 .auto-salvage-toggle:checked+.toggle-btn,
+.salvage-material-toggle:checked+.toggle-btn,
 .toggle-btn.checked {
   background: #2563eb;
   border-color: #2563eb;
@@ -697,6 +699,7 @@
 }
 
 .auto-salvage-toggle:checked+.toggle-btn::before,
+.salvage-material-toggle:checked+.toggle-btn::before,
 .toggle-btn.checked::before {
   left: 25px;
 }

--- a/src/inventory.js
+++ b/src/inventory.js
@@ -35,6 +35,7 @@ export default class Inventory {
     this.inventoryItems = savedData?.inventoryItems || new Array(ITEM_SLOTS).fill(null);
     this.materials = savedData?.materials || new Array(MATERIALS_SLOTS).fill(null);
     this.autoSalvageRarities = savedData?.autoSalvageRarities || [];
+    this.salvageUpgradeMaterials = savedData?.salvageUpgradeMaterials || false;
 
     if (savedData) {
       // Restore equipped items
@@ -344,10 +345,34 @@ export default class Inventory {
     return 25 * item.level * (RARITY_ORDER.indexOf(item.rarity) + 1) * item.tier;
   }
 
+  getItemSalvageMaterial(item) {
+    const rarityAmounts = {
+      NORMAL: 1,
+      MAGIC: 2,
+      RARE: 3,
+      UNIQUE: 5,
+      LEGENDARY: 7,
+      MYTHIC: 10,
+    };
+    const weaponTypes = getTypesByCategory('weapon');
+    const jewelryTypes = getTypesByCategory('jewelry');
+    let id;
+    if (weaponTypes.includes(item.type)) {
+      id = MATERIALS.WEAPON_UPGRADE_CORE.id;
+    } else if (jewelryTypes.includes(item.type)) {
+      id = MATERIALS.JEWELRY_UPGRADE_GEM.id;
+    } else {
+      id = MATERIALS.ARMOR_UPGRADE_STONE.id;
+    }
+    const qty = rarityAmounts[item.rarity] || 1;
+    return { id, qty };
+  }
+
   salvageItemsByRarity(rarity) {
     let salvagedItems = 0;
     let goldGained = 0;
     let crystalsGained = 0;
+    const matsGained = {};
 
     // Skip first PERSISTENT_SLOTS slots when salvaging
     this.inventoryItems = this.inventoryItems.map((item, index) => {
@@ -357,9 +382,12 @@ export default class Inventory {
         console.debug(rarity, '==', item.rarity);
 
         salvagedItems++;
-        // Give gold based on rarity and level (customize as needed)
-        goldGained += this.getItemSalvageValue(item);
-        // If mythic, give a crystal
+        if (this.salvageUpgradeMaterials) {
+          const { id, qty } = this.getItemSalvageMaterial(item);
+          matsGained[id] = (matsGained[id] || 0) + qty;
+        } else {
+          goldGained += this.getItemSalvageValue(item);
+        }
         if (item.rarity === 'MYTHIC') {
           crystalsGained++;
         }
@@ -369,11 +397,25 @@ export default class Inventory {
     });
 
     if (salvagedItems > 0) {
-      if (goldGained > 0) hero.gold = (hero.gold || 0) + goldGained;
+      if (this.salvageUpgradeMaterials) {
+        Object.entries(matsGained).forEach(([id, qty]) => {
+          this.addMaterial({ id, qty });
+        });
+      } else if (goldGained > 0) {
+        hero.gold = (hero.gold || 0) + goldGained;
+      }
       if (crystalsGained > 0) hero.crystals = (hero.crystals || 0) + crystalsGained;
       let msg = `Salvaged ${salvagedItems} ${rarity.toLowerCase()} items`;
-      if (goldGained > 0) msg += `, gained ${goldGained} gold`;
-      if (crystalsGained > 0) msg += `, gained ${crystalsGained} crystal${crystalsGained > 1 ? 's' : ''}`;
+      if (this.salvageUpgradeMaterials) {
+        const parts = Object.entries(matsGained).map(
+          ([id, qty]) => `${qty} ${MATERIALS[id].name}`,
+        );
+        if (parts.length) msg += `, gained ${parts.join(', ')}`;
+      } else if (goldGained > 0) {
+        msg += `, gained ${goldGained} gold`;
+      }
+      if (crystalsGained > 0)
+        msg += `, gained ${crystalsGained} crystal${crystalsGained > 1 ? 's' : ''}`;
       showToast(msg, 'success');
       updateInventoryGrid();
       updateMaterialsGrid();
@@ -544,6 +586,11 @@ export default class Inventory {
 
   setAutoSalvageRarities(rarities) {
     this.autoSalvageRarities = rarities;
+    dataManager.saveGame();
+  }
+
+  setSalvageUpgradeMaterials(value) {
+    this.salvageUpgradeMaterials = value;
     dataManager.saveGame();
   }
 


### PR DESCRIPTION
## Summary
- allow salvaging equipment for upgrade materials
- add toggle in salvage modal to enable material salvage
- show correct salvage values in tooltips
- style salvage material toggle alongside auto-salvage toggle

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686cebf01b9c83318bec4b419fa393fe