### PR TITLE
Add Prestige tab with bonuses

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="/src/css/training.css" />
     <link rel="stylesheet" href="/src/css/crystalShop.css" />
     <link rel="stylesheet" href="/src/css/soulShop.css" />
+    <link rel="stylesheet" href="/src/css/prestige.css" />
     <link rel="stylesheet" href="/src/css/inventory.css" />
     <link rel="stylesheet" href="/src/css/skillTree.css" />
     <link rel="stylesheet" href="/src/css/statistics.css" />
@@ -51,6 +52,7 @@
                 <button class="tab-btn" data-tab="skilltree">Skill Tree</button>
                 <button class="tab-btn" data-tab="crystalShop">Crystal Shop</button>
                 <button class="tab-btn" data-tab="soulShop">Soul Shop</button>
+                <button class="tab-btn" data-tab="prestige">Prestige</button>
                 <button class="tab-btn" data-tab="quests">Quests</button>
                 <button class="tab-btn" data-tab="statistics">Statistics</button>
                 <button class="tab-btn" data-tab="options">Options</button>
@@ -67,6 +69,7 @@
                 <div id="inventory" class="tab-panel"></div>
                 <div id="skilltree" class="tab-panel"></div>
                 <div id="soulShop" class="tab-panel"></div>
+                <div id="prestige" class="tab-panel"></div>
                 <div id="statistics" class="tab-panel"></div>
                 <div id="options" class="tab-panel"></div>
                 <div id="quests" class="tab-panel"></div>

--- a/src/constants/prestigeBonuses.js
+++ b/src/constants/prestigeBonuses.js
@@ -1,0 +1,27 @@
+export const PRESTIGE_BONUSES = [
+  {
+    stat: 'totalDamagePercent',
+    value: 0.05,
+    description: '+5% Total Damage',
+  },
+  {
+    stat: 'lifePercent',
+    value: 0.05,
+    description: '+5% Life',
+  },
+  {
+    stat: 'manaPercent',
+    value: 0.05,
+    description: '+5% Mana',
+  },
+  {
+    stat: 'bonusExperiencePercent',
+    value: 0.1,
+    description: '+10% Experience Gain',
+  },
+  {
+    stat: 'bonusGoldPercent',
+    value: 0.1,
+    description: '+10% Gold Gain',
+  },
+];

--- a/src/css/prestige.css
+++ b/src/css/prestige.css
@@ -1,0 +1,52 @@
+.prestige-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.prestige-header {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
+}
+
+.prestige-bonuses-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.prestige-bonuses-list li {
+  background: var(--bg-element);
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.prestige-modal-content {
+  background: var(--bg-element);
+  padding: 1rem;
+  border-radius: 0.75rem;
+  width: 360px;
+  text-align: center;
+}
+
+.prestige-cards {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+.prestige-card {
+  background: var(--bg-element);
+  border: 1px solid var(--accent);
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  cursor: pointer;
+  flex: 1 1 0;
+}
+
+.prestige-card:hover {
+  background: #2d3340;
+}

--- a/src/globals.js
+++ b/src/globals.js
@@ -10,6 +10,7 @@ import SoulShop from './soulShop.js';
 import Statistics from './statistics.js';
 import Training from './training.js';
 import { BuildingManager } from './building.js';
+import Prestige from './prestige.js';
 
 // Global singletons for the game
 export let game = null;
@@ -24,6 +25,7 @@ export let soulShop = null;
 export let options = null;
 export let dataManager = null;
 export let buildings = null;
+export let prestige = null;
 
 // Setters for initialization in main.js
 export async function setGlobals({ cloud = false, reset = false } = {}) {
@@ -47,6 +49,7 @@ export async function setGlobals({ cloud = false, reset = false } = {}) {
   const _soulShop = new SoulShop(savedData?.soulShop);
   const _options = new Options(savedData?.options);
   const _buildings = new BuildingManager(savedData?.buildings);
+  const _prestige = new Prestige(savedData?.prestige);
 
   game = _game;
   hero = _hero;
@@ -59,6 +62,7 @@ export async function setGlobals({ cloud = false, reset = false } = {}) {
   soulShop = _soulShop;
   buildings = _buildings;
   options = _options;
+  prestige = _prestige;
   dataManager = _dataManager;
 
   // useful when loading from cloud
@@ -78,6 +82,7 @@ export function getGlobals() {
     soulShop,
     buildings,
     options,
+    prestige,
     dataManager,
   };
 }

--- a/src/main.js
+++ b/src/main.js
@@ -18,10 +18,12 @@ import {
   options,
   dataManager,
   buildings,
+  prestige,
 } from './globals.js';
 import { initializeRegionSystem, updateRegionUI } from './region.js';
 import { updateStatsAndAttributesUI } from './ui/statsAndAttributesUi.js';
 import { initializeBuildingsUI } from './ui/buildingUi.js';
+import { initializePrestigeUI } from './ui/prestigeUi.js';
 import Enemy from './enemy.js';
 import { setupLeaderboardTabLazyLoad } from './ui/leaderboardUi.js';
 
@@ -45,6 +47,7 @@ window.log = console.log;
   options.initializeOptionsUI();
   initializeSkillTreeUI();
   initializeBuildingsUI();
+  initializePrestigeUI();
 
   updateResources();
   hero.recalculateFromAttributes();

--- a/src/prestige.js
+++ b/src/prestige.js
@@ -1,0 +1,65 @@
+import { hero, dataManager, setGlobals, prestige as prestigeState } from './globals.js';
+import { PRESTIGE_BONUSES } from './constants/prestigeBonuses.js';
+import { updateStatsAndAttributesUI } from './ui/statsAndAttributesUi.js';
+import { updateResources, showToast } from './ui/ui.js';
+
+export default class Prestige {
+  constructor(savedData = null) {
+    this.prestigeCount = 0;
+    this.bonuses = {};
+    Object.assign(this, savedData);
+    this.modal = null;
+  }
+
+  canPrestige() {
+    return hero.level >= 50;
+  }
+
+  getBonuses() {
+    return this.bonuses;
+  }
+
+  addBonuses(b) {
+    Object.entries(b).forEach(([stat, val]) => {
+      this.bonuses[stat] = (this.bonuses[stat] || 0) + val;
+      hero.permaStats[stat] = (hero.permaStats[stat] || 0) + val;
+    });
+  }
+
+  generateCards(count = 3, bonusesPerCard = 3) {
+    const cards = [];
+    for (let i = 0; i < count; i++) {
+      const shuffled = [...PRESTIGE_BONUSES].sort(() => 0.5 - Math.random());
+      const picked = shuffled.slice(0, bonusesPerCard);
+      const card = { bonuses: {}, descriptions: [] };
+      picked.forEach((b) => {
+        card.bonuses[b.stat] = (card.bonuses[b.stat] || 0) + b.value;
+        card.descriptions.push(b.description);
+      });
+      cards.push(card);
+    }
+    return cards;
+  }
+
+  async prestigeWithBonus(card) {
+    const combined = { ...this.bonuses };
+    Object.entries(card.bonuses).forEach(([stat, val]) => {
+      combined[stat] = (combined[stat] || 0) + val;
+    });
+    const newCount = this.prestigeCount + 1;
+
+    await setGlobals({ reset: true });
+
+    prestigeState.bonuses = combined;
+    prestigeState.prestigeCount = newCount;
+    Object.entries(combined).forEach(([stat, val]) => {
+      hero.permaStats[stat] = (hero.permaStats[stat] || 0) + val;
+    });
+
+    hero.recalculateFromAttributes();
+    updateResources();
+    updateStatsAndAttributesUI();
+    showToast('Prestige complete!');
+    dataManager.saveGame();
+  }
+}

--- a/src/ui/prestigeUi.js
+++ b/src/ui/prestigeUi.js
@@ -1,0 +1,73 @@
+import { prestige } from '../globals.js';
+import { createModal, closeModal } from './modal.js';
+
+const html = String.raw;
+
+export function initializePrestigeUI() {
+  const tab = document.getElementById('prestige');
+  if (!tab) return;
+
+  let container = tab.querySelector('.prestige-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.className = 'prestige-container';
+    tab.innerHTML = '';
+    tab.appendChild(container);
+  }
+
+  container.innerHTML = `
+    <div class="prestige-header">
+      <button id="prestige-now-btn">Prestige Now</button>
+    </div>
+    <ul class="prestige-bonuses-list"></ul>
+  `;
+
+  container.querySelector('#prestige-now-btn').onclick = () => {
+    if (prestige.canPrestige()) openPrestigeModal();
+  };
+
+  updatePrestigeBonuses();
+}
+
+export function updatePrestigeBonuses() {
+  const tab = document.getElementById('prestige');
+  if (!tab) return;
+  const list = tab.querySelector('.prestige-bonuses-list');
+  if (!list) return;
+  const bonuses = prestige.getBonuses();
+  list.innerHTML = Object.keys(bonuses).length
+    ? Object.entries(bonuses)
+      .map(([stat, val]) => `<li>${stat}: +${(val * 100).toFixed(1)}%</li>`)
+      .join('')
+    : '<li>No prestige bonuses yet.</li>';
+}
+
+function openPrestigeModal() {
+  const cards = prestige.generateCards(3);
+  const content = html`
+    <div class="prestige-modal-content">
+      <button class="modal-close">&times;</button>
+      <div class="prestige-cards">
+        ${cards
+    .map(
+      (c, i) => `
+              <div class="prestige-card" data-idx="${i}">
+                <ul>${c.descriptions.map((d) => `<li>${d}</li>`).join('')}</ul>
+              </div>
+            `,
+    )
+    .join('')}
+      </div>
+    </div>
+  `;
+
+  const modal = createModal({ id: 'prestige-modal', className: 'prestige-modal', content });
+  modal.querySelectorAll('.prestige-card').forEach((el) => {
+    el.onclick = async () => {
+      const idx = parseInt(el.dataset.idx, 10);
+      await prestige.prestigeWithBonus(cards[idx]);
+      closeModal(modal);
+      updatePrestigeBonuses();
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- implement prestige bonuses list in `PRESTIGE_BONUSES`
- generate prestige cards with three random bonuses each
- reset game with `setGlobals({reset: true})` while preserving bonuses
- update UI for new card format

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686d2bcea47c8331a7ae0b9b266c2b0c