### PR TITLE
Add rewarded ad placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
                 <div class="resource resource-gold"><span class="icon">💰</span><span id="gold"></span></div>
                 <div class="resource resource-crystal"><span class="icon">💎</span><span id="crystals"></span></div>
                 <div class="resource resource-souls"><span class="icon">👻</span><span id="souls"></span></div>
+                <button id="watch-ad-btn" class="watch-ad-btn">Watch Ad</button>
             </div>
 
             <div class="tab-buttons">

--- a/src/ads.js
+++ b/src/ads.js
@@ -1,0 +1,47 @@
+import { createModal, closeModal } from './ui/modal.js';
+import { hero } from './globals.js';
+import { updateResources, showToast } from './ui/ui.js';
+import { AD_BONUSES } from './constants/adBonuses.js';
+
+export function initializeAds() {
+  const btn = document.getElementById('watch-ad-btn');
+  if (btn) {
+    btn.addEventListener('click', showRewardAd);
+  }
+}
+
+function applyAdBonuses() {
+  AD_BONUSES.forEach((b) => {
+    if (b.type === 'gold') hero.gainGold(b.amount);
+    else if (b.type === 'crystals') hero.gainCrystals(b.amount);
+    else if (b.type === 'souls') hero.gainSouls(b.amount);
+  });
+  updateResources();
+  showToast('Ad watched! Bonuses applied.', 'success');
+}
+
+export function showRewardAd() {
+  let remaining = 5;
+  const content = `
+    <div class="modal-content">
+      <h2>Advertisement</h2>
+      <p>Watching ad... <span id="ad-countdown">${remaining}</span></p>
+    </div>
+  `;
+  const modal = createModal({
+    id: 'ad-modal',
+    className: 'ad-modal',
+    content,
+    closeOnOutsideClick: false,
+  });
+  const counter = modal.querySelector('#ad-countdown');
+  const timer = setInterval(() => {
+    remaining -= 1;
+    if (counter) counter.textContent = remaining;
+    if (remaining <= 0) {
+      clearInterval(timer);
+      closeModal('ad-modal');
+      applyAdBonuses();
+    }
+  }, 1000);
+}

--- a/src/constants/adBonuses.js
+++ b/src/constants/adBonuses.js
@@ -1,0 +1,10 @@
+export const AD_BONUSES = [
+  {
+    type: 'gold',
+    amount: 100,
+  },
+  {
+    type: 'crystals',
+    amount: 1,
+  },
+];

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -40,6 +40,19 @@
   gap: 0.5rem;
 }
 
+.watch-ad-btn {
+  background-color: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.watch-ad-btn:hover {
+  background-color: #2563eb;
+}
+
 .main-content {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/src/main.js
+++ b/src/main.js
@@ -25,6 +25,7 @@ import { initializeBuildingsUI, renderPurchasedBuildings } from './ui/buildingUi
 import { initializePrestigeUI } from './ui/prestigeUi.js';
 import Enemy from './enemy.js';
 import { setupLeaderboardTabLazyLoad } from './ui/leaderboardUi.js';
+import { initializeAds } from './ads.js';
 
 window.qwe = console.log;
 window.qw = console.log;
@@ -40,6 +41,7 @@ window.log = console.log;
   game.currentEnemy = new Enemy(game.stage);
 
   initializeUI();
+  initializeAds();
   crystalShop.initializeCrystalShopUI();
   soulShop.initializeSoulShopUI();
   statistics.initializeStatisticsUI();


### PR DESCRIPTION
## Summary
- create an `AD_BONUSES` constant describing the reward for watching an ad
- add a placeholder ad system that shows a countdown modal
- show a `Watch Ad` button in the sidebar resource area
- style the ad button
- initialize the ad system from `main.js`

## Testing
- `npm run lint` *(fails: Unknown env config http-proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687fd90223fc8331850742f2c5eaae2c