### PR TITLE
Implement mobile-friendly inventory

### DIFF
--- a/src/css/inventory.css
+++ b/src/css/inventory.css
@@ -323,6 +323,15 @@
   gap: 8px;
 }
 
+.mobile-equip-btn {
+  background: #2e7d32;
+  border: 1px solid #3fa043;
+  color: #fff;
+}
+.mobile-equip-btn:hover {
+  background: #388e3c;
+}
+
 .salvage-options {
   display: none;
   position: absolute;
@@ -751,4 +760,47 @@
   padding: 4px 8px;
   border-radius: 0.5rem;
   background: var(--bg-element);
+}
+
+/* Mobile interaction helpers */
+.inventory-item.selected {
+  outline: 2px solid #4caf50;
+}
+
+.equipment-slot.selected-slot {
+  box-shadow: 0 0 0 2px #4caf50 inset;
+}
+
+.equipment-slot.eligible-slot {
+  background-color: rgba(76, 175, 80, 0.2);
+}
+
+.equipment-slot.ineligible-slot {
+  background-color: rgba(244, 67, 54, 0.2);
+}
+
+.item-context-menu {
+  position: absolute;
+  background: var(--bg-element);
+  color: #fff;
+  border: 1px solid #555;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+  z-index: 2000;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+}
+
+.item-context-menu button {
+  background: none;
+  border: none;
+  color: inherit;
+  padding: 6px 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.item-context-menu button:hover {
+  background: var(--bg-panel);
 }


### PR DESCRIPTION
## Summary
- add green mobile equip button next to salvage
- prevent duplicate items by unequipping when tapping the same slot
- lighten item context menu styling
- allow context menu equip to instantly equip unless item is a ring

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6880158fb6b88331a3ddf2dcca99e00d