### PR TITLE
Improve readability of numeric stats

### DIFF
--- a/src/building.js
+++ b/src/building.js
@@ -1,7 +1,7 @@
 // Game logic and persistent state for buildings
 import { buildingsData } from './constants/buildings.js';
 import { dataManager, hero } from './globals.js';
-import { updateResources } from './ui/ui.js';
+import { updateResources, formatNumber } from './ui/ui.js';
 import { showOfflineBonusesModal } from './ui/buildingUi.js';
 import { fetchTrustedUtcTime } from './api.js';
 import { getTimeNow } from './common.js';
@@ -64,7 +64,7 @@ export class Building {
   static formatCost(costObj) {
     if (!costObj || typeof costObj !== 'object') return '';
     return Object.entries(costObj)
-      .map(([type, value]) => `${value} ${type}`)
+      .map(([type, value]) => `${formatNumber(value)} ${type}`)
       .join(', ');
   }
 

--- a/src/statistics.js
+++ b/src/statistics.js
@@ -1,4 +1,5 @@
 import { handleSavedData } from './functions.js';
+import { formatNumber } from './ui/ui.js';
 
 /**
  * @class Statistics
@@ -85,7 +86,7 @@ export default class Statistics {
     // Bosses Killed
     const bossesKilledElem = document.getElementById('stat-bosses-killed');
     if (bossesKilledElem) {
-      bossesKilledElem.textContent = `Bosses Defeated: ${this.bossesKilled}`;
+      bossesKilledElem.textContent = `Bosses Defeated: ${formatNumber(this.bossesKilled)}`;
     }
 
     // Total Time Played (resets on reset)
@@ -100,43 +101,43 @@ export default class Statistics {
     // Total Enemies Killed
     const enemiesKilled = document.getElementById('stat-enemies-killed');
     if (enemiesKilled) {
-      enemiesKilled.textContent = `Total Enemies Killed: ${this.enemiesKilled.total || 0}`;
+      enemiesKilled.textContent = `Total Enemies Killed: ${formatNumber(this.enemiesKilled.total || 0)}`;
     }
 
     // Highest Damage Dealt
     const highestDamage = document.getElementById('stat-highest-damage');
     if (highestDamage) {
-      highestDamage.textContent = `Highest Damage Dealt: ${Math.floor(this.highestDamageDealt) || 0}`;
+      highestDamage.textContent = `Highest Damage Dealt: ${formatNumber(Math.floor(this.highestDamageDealt) || 0)}`;
     }
 
     // Total Gold Earned
     const totalGold = document.getElementById('stat-total-gold');
     if (totalGold) {
-      totalGold.textContent = `Total Gold Earned: ${this.totalGoldEarned || 0}`;
+      totalGold.textContent = `Total Gold Earned: ${formatNumber(this.totalGoldEarned || 0)}`;
     }
 
     // Total Crystals Earned
     const totalCrystals = document.getElementById('stat-total-crystals');
     if (totalCrystals) {
-      totalCrystals.textContent = `Total Crystals Earned: ${this.totalCrystalsEarned || 0}`;
+      totalCrystals.textContent = `Total Crystals Earned: ${formatNumber(this.totalCrystalsEarned || 0)}`;
     }
 
     // Total Souls Earned
     const totalSouls = document.getElementById('stat-total-souls');
     if (totalSouls) {
-      totalSouls.textContent = `Total Souls Earned: ${this.totalSoulsEarned || 0}`;
+      totalSouls.textContent = `Total Souls Earned: ${formatNumber(this.totalSoulsEarned || 0)}`;
     }
 
     // Total Items Found
     const itemsFound = document.getElementById('stat-items-found');
     if (itemsFound) {
-      itemsFound.textContent = `Total Items Found: ${this.totalItemsFound || 0}`;
+      itemsFound.textContent = `Total Items Found: ${formatNumber(this.totalItemsFound || 0)}`;
     }
 
     // Total Materials Found
     const materialsFound = document.getElementById('stat-materials-found');
     if (materialsFound) {
-      materialsFound.textContent = `Total Materials Found: ${this.totalMaterialsFound || 0}`;
+      materialsFound.textContent = `Total Materials Found: ${formatNumber(this.totalMaterialsFound || 0)}`;
     }
 
     // Highest Stages Reached
@@ -146,7 +147,7 @@ export default class Statistics {
       for (let i = 1; i <= 12; i++) {
         const span = document.createElement('span');
         span.className = 'stage-value';
-        span.textContent = `T${i}: ${this.highestStages[i] || 0}`;
+        span.textContent = `T${i}: ${formatNumber(this.highestStages[i] || 0)}`;
         parts.push(span);
         if (i < 12) {
           const sep = document.createElement('span');

--- a/src/training.js
+++ b/src/training.js
@@ -1,4 +1,4 @@
-import { formatStatName, updateResources } from './ui/ui.js';
+import { formatStatName, updateResources, formatNumber } from './ui/ui.js';
 
 import { showToast } from './ui/ui.js';
 import { hero, dataManager } from './globals.js';
@@ -148,9 +148,9 @@ export default class Training {
     // Set title and base info
     const m = this.modal;
     m.querySelector('.modal-title').textContent = formatStatName(stat);
-    m.querySelector('.modal-level').textContent = this.upgradeLevels[stat] || 0;
+    m.querySelector('.modal-level').textContent = formatNumber(this.upgradeLevels[stat] || 0);
     m.querySelector('.modal-max-level').textContent =
-      trainingConfig?.maxLevel === Infinity ? '∞' : trainingConfig.maxLevel;
+      trainingConfig?.maxLevel === Infinity ? '∞' : formatNumber(trainingConfig.maxLevel);
     m.querySelector('.modal-bonus').textContent = this.getBonusText(
       stat,
       STATS[stat].training,
@@ -227,13 +227,13 @@ export default class Training {
     const decimals = STATS[stat].decimalPlaces || 0;
 
     // --- Update ALL modal fields ---
-    this.modal.querySelector('.modal-qty').textContent = qty;
-    this.modal.querySelector('.modal-total-cost').textContent = totalCost;
-    this.modal.querySelector('.modal-total-bonus').textContent = `+${bonusValue.toFixed(decimals)} ${formatStatName(
-      stat,
-    )}`;
-    this.modal.querySelector('.modal-level').textContent = baseLevel;
-    this.modal.querySelector('.modal-max-level').textContent = maxLevel === Infinity ? '∞' : maxLevel;
+    this.modal.querySelector('.modal-qty').textContent = formatNumber(qty);
+    this.modal.querySelector('.modal-total-cost').textContent = formatNumber(totalCost);
+    this.modal.querySelector('.modal-total-bonus').textContent = `+${formatNumber(
+      bonusValue.toFixed(decimals),
+    )} ${formatStatName(stat)}`;
+    this.modal.querySelector('.modal-level').textContent = formatNumber(baseLevel);
+    this.modal.querySelector('.modal-max-level').textContent = maxLevel === Infinity ? '∞' : formatNumber(maxLevel);
     this.modal.querySelector('.modal-bonus').textContent = this.getBonusText(stat, config, baseLevel);
     this.modal.querySelector('.modal-next-bonus').textContent = this.getBonusText(stat, config, baseLevel + 1);
 
@@ -260,7 +260,7 @@ export default class Training {
 
     return html`
       <button data-stat="${stat}" ${isMaxed ? ' disabled' : ''}>
-        <span class="upgrade-name">${formatStatName(stat)} (Lvl ${level}${isMaxed ? ' / Max' : ''})</span>
+        <span class="upgrade-name">${formatStatName(stat)} (Lvl ${formatNumber(level)}${isMaxed ? ' / Max' : ''})</span>
         <span class="upgrade-bonus">${bonus}${isMaxed ? ' <strong>Max</strong>' : ''}</span>
       </button>
     `;
@@ -268,7 +268,7 @@ export default class Training {
   getBonusText(stat, config, level) {
     const value = config.bonus * level;
     const decimals = STATS[stat].decimalPlaces || 0;
-    const formattedValue = value.toFixed(decimals);
+    const formattedValue = formatNumber(value.toFixed(decimals));
     return `+${formattedValue}${config.suffix || ''} ${formatStatName(stat)}`;
   }
 

--- a/src/ui/buildingUi.js
+++ b/src/ui/buildingUi.js
@@ -5,7 +5,7 @@ const html = String.raw;
 import { buildings, dataManager, hero } from '../globals.js';
 import { Building } from '../building.js';
 import { createModal, closeModal } from './modal.js';
-import { showConfirmDialog, updateResources } from './ui.js';
+import { showConfirmDialog, updateResources, formatNumber } from './ui.js';
 
 function createBuildingCard(building) {
   const el = document.createElement('div');
@@ -17,7 +17,7 @@ function createBuildingCard(building) {
     <div class="building-info">
       <div class="building-name">${building.name}</div>
       <div class="building-effect">${building.formatEffect()}</div>
-      <div class="building-earned">Total Earned: ${building.totalEarned} ${building.effect?.type || ''}</div>
+      <div class="building-earned">Total Earned: ${formatNumber(building.totalEarned)} ${building.effect?.type || ''}</div>
     </div>
   `;
   return el;
@@ -67,14 +67,14 @@ function showBuildingInfoModal(building, onUpgrade, placementOptions) {
           </div>
         </div>
         <div class="building-info-modal-body">
-          <div>Level: <b>${building.level}</b> / ${building.maxLevel}</div>
+          <div>Level: <b>${formatNumber(building.level)}</b> / ${formatNumber(building.maxLevel)}</div>
           <div>Current Bonus: <b>${building.formatEffect()}</b></div>
-          <div>Upgrade Amount: <b>${upgradeAmount}</b></div>
+          <div>Upgrade Amount: <b>${formatNumber(upgradeAmount)}</b></div>
           <div>Total Upgrade Cost: <b>${Building.formatCost(totalCost)}</b></div>
           <div>
             Bonus After Upgrade:
             <b>${building.formatEffect(building.level + upgradeAmount)}</b>
-            <span style="color:#aaa;font-size:0.95em;">(+${totalBonus} ${building.effect?.type || ''})</span>
+            <span style="color:#aaa;font-size:0.95em;">(+${formatNumber(totalBonus)} ${building.effect?.type || ''})</span>
           </div>
         </div>
         <div class="building-info-modal-upgrade">
@@ -424,7 +424,7 @@ export function showOfflineBonusesModal(bonuses, onCollect) {
         ${bonuses
     .map(
       (b) =>
-        `<li style='margin:10px 0;font-size:1.1em;'>${b.icon || ''} <b>${b.name}</b>: +${b.amount} ${
+        `<li style='margin:10px 0;font-size:1.1em;'>${b.icon || ''} <b>${b.name}</b>: +${formatNumber(b.amount)} ${
           b.type
         } <span style='color:#aaa;font-size:0.95em;'>(for ${b.times} ${b.interval}${
           b.times > 1 ? 's' : ''

--- a/src/ui/prestigeUi.js
+++ b/src/ui/prestigeUi.js
@@ -1,6 +1,6 @@
 import { prestige } from '../globals.js';
 import { createModal, closeModal } from './modal.js';
-import { formatStatName, showToast } from './ui.js';
+import { formatStatName, showToast, formatNumber } from './ui.js';
 
 const html = String.raw;
 
@@ -111,5 +111,5 @@ export function formatPrestigeBonus(stat, value) {
   if (stat.endsWith('Percent')) {
     return `+${(value * 100).toFixed(1)}%`;
   }
-  return `+${Math.round(value)}`;
+  return `+${formatNumber(Math.round(value))}`;
 }

--- a/src/ui/questUi.js
+++ b/src/ui/questUi.js
@@ -1,5 +1,5 @@
 // Quest UI logic moved from ui.js
-import { showTooltip, hideTooltip, positionTooltip } from './ui.js';
+import { showTooltip, hideTooltip, positionTooltip, formatNumber } from './ui.js';
 import { quests } from '../globals.js';
 
 export function updateQuestsUI() {
@@ -102,7 +102,7 @@ export function openQuestModal(quest) {
   modal.querySelector('#quest-modal-desc').textContent = quest.description;
   // Add progress display in green
   const progress = quest.getProgress();
-  const progressHtml = `<span style=\"color:#22c55e;font-weight:bold;\">${progress}/${quest.target}</span>`;
+  const progressHtml = `<span style=\"color:#22c55e;font-weight:bold;\">${formatNumber(progress)}/${formatNumber(quest.target)}</span>`;
   // Add reward display: gold in yellow, crystals in blue, others default
   let rewardParts = [];
   for (const [key, value] of Object.entries(quest.reward)) {
@@ -117,7 +117,7 @@ export function openQuestModal(quest) {
       );
     } else {
       rewardParts.push(
-        `<span style=\"color:${color};font-weight:bold;\">${value} ${key.charAt(0).toUpperCase() + key.slice(1)}</span>`,
+        `<span style=\"color:${color};font-weight:bold;\">${formatNumber(value)} ${key.charAt(0).toUpperCase() + key.slice(1)}</span>`,
       );
     }
   }
@@ -184,7 +184,7 @@ function openClaimableQuestsModal() {
       item.innerHTML = `
         <span class="quest-icon">${q.icon}</span>
         <span class="quest-title">${q.title}</span>
-        <span class="quest-progress">${q.getProgress()}/${q.target}</span>
+        <span class="quest-progress">${formatNumber(q.getProgress())}/${formatNumber(q.target)}</span>
         <button class="modal-btn" style="margin-left:auto;">Claim</button>
       `;
       // Show tooltip on hover

--- a/src/ui/statsAndAttributesUi.js
+++ b/src/ui/statsAndAttributesUi.js
@@ -1,6 +1,6 @@
 import { game, hero, statistics } from '../globals.js';
 import { STATS } from '../constants/stats/stats.js';
-import { hideTooltip, positionTooltip, showTooltip, updateEnemyStats } from '../ui/ui.js';
+import { hideTooltip, positionTooltip, showTooltip, updateEnemyStats, formatNumber } from '../ui/ui.js';
 import { OFFENSE_STATS } from '../constants/stats/offenseStats.js';
 import { DEFENSE_STATS } from '../constants/stats/defenseStats.js';
 import { MISC_STATS } from '../constants/stats/miscStats.js';
@@ -37,10 +37,10 @@ export function updateStatsAndAttributesUI() {
     statsContainer.className = 'stats-container';
     // Header: level, EXP
     const headerHtml = html`
-      <div><strong>Level:</strong> <span id="level-value">${hero.level || 1}</span></div>
+      <div><strong>Level:</strong> <span id="level-value">${formatNumber(hero.level || 1)}</span></div>
       <div>
-        <strong>EXP:</strong> <span id="exp-value">${hero.exp || 0}</span> /
-        <span id="exp-to-next-level-value">${hero.getExpToNextLevel() || 100}</span>
+        <strong>EXP:</strong> <span id="exp-value">${formatNumber(hero.exp || 0)}</span> /
+        <span id="exp-to-next-level-value">${formatNumber(hero.getExpToNextLevel() || 100)}</span>
         (<span id="exp-progress">${((hero.exp / hero.getExpToNextLevel()) * 100).toFixed(1)}%</span>)
       </div>
       <hr style="border: none; border-top: 1px solid #fff; margin: 10px 0;" />
@@ -95,7 +95,9 @@ export function updateStatsAndAttributesUI() {
         if (key === 'extraMaterialDropPercent') {
           val = (val * 100).toFixed(1) + '%';
         } else if (typeof val === 'number' && statsDef[key].decimalPlaces !== undefined) {
-          val = val.toFixed(statsDef[key].decimalPlaces);
+          val = formatNumber(val.toFixed(statsDef[key].decimalPlaces));
+        } else {
+          val = formatNumber(val);
         }
         span.textContent = val;
         row.appendChild(lbl);
@@ -142,7 +144,7 @@ export function updateStatsAndAttributesUI() {
           const span = document.createElement('span');
           span.id = `${key}-value`;
           let val = hero.stats[key];
-          span.textContent = val;
+          span.textContent = formatNumber(val);
           row.appendChild(icon);
           row.appendChild(lbl);
           row.appendChild(document.createTextNode(' '));
@@ -178,7 +180,7 @@ export function updateStatsAndAttributesUI() {
           const span = document.createElement('span');
           span.id = `${key}-value`;
           let val = hero.stats[key];
-          span.textContent = val;
+          span.textContent = formatNumber(val);
           row.appendChild(icon);
           row.appendChild(lbl);
           row.appendChild(document.createTextNode(' '));
@@ -215,7 +217,7 @@ export function updateStatsAndAttributesUI() {
       if (el) {
         // Special formatting for certain stats
         if (key === 'attackSpeed') {
-          el.textContent = hero.stats.attackSpeed.toFixed(STATS.attackSpeed.decimalPlaces);
+          el.textContent = formatNumber(hero.stats.attackSpeed.toFixed(STATS.attackSpeed.decimalPlaces));
         } else if (key === 'critChance') {
           el.textContent = hero.stats.critChance.toFixed(STATS.critChance.decimalPlaces) + '%';
         } else if (key === 'critDamage') {
@@ -223,9 +225,9 @@ export function updateStatsAndAttributesUI() {
         } else if (key === 'lifeSteal') {
           el.textContent = hero.stats.lifeSteal.toFixed(STATS.lifeSteal.decimalPlaces) + '%';
         } else if (key === 'lifeRegen') {
-          el.textContent = hero.stats.lifeRegen.toFixed(STATS.lifeRegen.decimalPlaces);
+          el.textContent = formatNumber(hero.stats.lifeRegen.toFixed(STATS.lifeRegen.decimalPlaces));
         } else if (key === 'manaRegen') {
-          el.textContent = hero.stats.manaRegen.toFixed(STATS.manaRegen.decimalPlaces);
+          el.textContent = formatNumber(hero.stats.manaRegen.toFixed(STATS.manaRegen.decimalPlaces));
         } else if (key === 'blockChance') {
           el.textContent = hero.stats.blockChance.toFixed(STATS.blockChance.decimalPlaces) + '%';
         } else if (key === 'bonusGoldPercent') {
@@ -237,22 +239,22 @@ export function updateStatsAndAttributesUI() {
           el.textContent =
             (hero.stats.extraMaterialDropPercent * 100).toFixed(STATS.extraMaterialDropPercent.decimalPlaces) + '%';
         } else {
-          el.textContent = hero.stats[key];
+          el.textContent = formatNumber(hero.stats[key]);
         }
       }
     });
 
     // Update header values
-    document.getElementById('level-value').textContent = hero.level || 1;
-    document.getElementById('exp-value').textContent = hero.exp || 0;
+    document.getElementById('level-value').textContent = formatNumber(hero.level || 1);
+    document.getElementById('exp-value').textContent = formatNumber(hero.exp || 0);
     document.getElementById('exp-progress').textContent =
       ((hero.exp / hero.getExpToNextLevel()) * 100).toFixed(1) + '%';
-    document.getElementById('exp-to-next-level-value').textContent = hero.getExpToNextLevel() || 100;
+    document.getElementById('exp-to-next-level-value').textContent = formatNumber(hero.getExpToNextLevel() || 100);
 
     // Add hit chance percentage to attackRating
     const attackRatingEl = document.getElementById('attackRating-value');
     if (attackRatingEl) {
-      attackRatingEl.textContent = hero.stats.attackRating;
+      attackRatingEl.textContent = formatNumber(hero.stats.attackRating);
       const hitPct = calculateHitChance(hero.stats.attackRating, game.currentEnemy.evasion).toFixed(2) + '%';
       attackRatingEl.appendChild(document.createTextNode(` (${hitPct})`));
     }
@@ -260,7 +262,7 @@ export function updateStatsAndAttributesUI() {
     // Add armor reduction percentage to armor
     const armorEl = document.getElementById('armor-value');
     if (armorEl) {
-      armorEl.textContent = hero.stats.armor || 0;
+      armorEl.textContent = formatNumber(hero.stats.armor || 0);
       // Use PoE2 formula: reduction = armor / (armor + 10 * enemy damage)
       const reduction = calculateArmorReduction(hero.stats.armor, game.currentEnemy.damage);
       armorEl.appendChild(document.createTextNode(` (${reduction.toFixed(2)}%)`));
@@ -269,7 +271,7 @@ export function updateStatsAndAttributesUI() {
     // add evasion reduction percentage to evasion
     const evasionEl = document.getElementById('evasion-value');
     if (evasionEl) {
-      evasionEl.textContent = hero.stats.evasion || 0;
+      evasionEl.textContent = formatNumber(hero.stats.evasion || 0);
       const er = calculateEvasionChance(hero.stats.evasion, game.currentEnemy.attackRating).toFixed(2) + '%';
       evasionEl.appendChild(document.createTextNode(` (${er})`));
     }
@@ -298,7 +300,7 @@ export function updateStatsAndAttributesUI() {
             <div class="attribute-row">
               <button class="allocate-btn" data-stat="${stat}">+</button>
               <strong>${displayName}:</strong>
-              <span id="${stat}-value">${hero.stats[stat]}</span>
+              <span id="${stat}-value">${formatNumber(hero.stats[stat])}</span>
             </div>
           `;
     })
@@ -372,14 +374,14 @@ export function updateStatsAndAttributesUI() {
   } else {
     document.getElementById('attributes').textContent = `Attributes (+${hero.statPoints})`;
     // Update dynamic attribute values
-    document.getElementById('strength-value').textContent = hero.stats['strength'];
-    document.getElementById('agility-value').textContent = hero.stats['agility'];
-    document.getElementById('vitality-value').textContent = hero.stats['vitality'];
-    document.getElementById('wisdom-value').textContent = hero.stats['wisdom'];
-    document.getElementById('endurance-value').textContent = hero.stats['endurance'];
-    document.getElementById('dexterity-value').textContent = hero.stats['dexterity'];
-    document.getElementById('intelligence-value').textContent = hero.stats['intelligence'] || 0;
-    document.getElementById('perseverance-value').textContent = hero.stats['perseverance'] || 0;
+    document.getElementById('strength-value').textContent = formatNumber(hero.stats['strength']);
+    document.getElementById('agility-value').textContent = formatNumber(hero.stats['agility']);
+    document.getElementById('vitality-value').textContent = formatNumber(hero.stats['vitality']);
+    document.getElementById('wisdom-value').textContent = formatNumber(hero.stats['wisdom']);
+    document.getElementById('endurance-value').textContent = formatNumber(hero.stats['endurance']);
+    document.getElementById('dexterity-value').textContent = formatNumber(hero.stats['dexterity']);
+    document.getElementById('intelligence-value').textContent = formatNumber(hero.stats['intelligence'] || 0);
+    document.getElementById('perseverance-value').textContent = formatNumber(hero.stats['perseverance'] || 0);
   }
 
   const skillTreeTab = document.querySelector('[data-tab="skilltree"]');

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -20,6 +20,16 @@ let tabIndicatorManager = null;
 
 const html = String.raw;
 
+// Format numbers with thousands separators.
+// Accepts numbers or numeric strings and returns a string with the given
+// separator (default comma) applied to the integer part.
+export function formatNumber(value, separator = ',') {
+  if (value === null || value === undefined) return value;
+  const parts = value.toString().split('.');
+  parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, separator);
+  return parts.join('.');
+}
+
 export function initializeUI() {
   game.activeTab = 'stats'; // Match the default active tab in HTML
 
@@ -151,83 +161,83 @@ export function updateResources() {
   }
 
   // Update ghost icon (total souls)
-  document.getElementById('souls').textContent = hero.souls || 0;
-  document.getElementById('crystals').textContent = hero.crystals || 0;
+  document.getElementById('souls').textContent = formatNumber(hero.souls || 0);
+  document.getElementById('crystals').textContent = formatNumber(hero.crystals || 0);
 
   // Update other stats
-  document.getElementById('gold').textContent = hero.gold || 0;
+  document.getElementById('gold').textContent = formatNumber(hero.gold || 0);
 }
 
 export function updatePlayerLife() {
   const stats = hero.stats;
   const lifePercentage = (stats.currentLife / stats.life) * 100;
   document.getElementById('life-fill').style.width = `${lifePercentage}%`;
-  document.getElementById('life-text').textContent = `${Math.max(0, Math.floor(stats.currentLife))}/${Math.floor(
-    stats.life,
-  )}`;
+  document.getElementById('life-text').textContent = `${formatNumber(
+    Math.max(0, Math.floor(stats.currentLife)),
+  )}/${formatNumber(Math.floor(stats.life))}`;
 
   const manaPercentage = (stats.currentMana / stats.mana) * 100;
   document.getElementById('mana-fill').style.width = `${manaPercentage}%`;
-  document.getElementById('mana-text').textContent = `${Math.max(0, Math.floor(stats.currentMana))}/${Math.floor(
-    stats.mana,
-  )}`;
+  document.getElementById('mana-text').textContent = `${formatNumber(
+    Math.max(0, Math.floor(stats.currentMana)),
+  )}/${formatNumber(Math.floor(stats.mana))}`;
 }
 
 export function updateEnemyStats() {
   const enemy = game.currentEnemy;
   const lifePercentage = (enemy.currentLife / enemy.life) * 100;
   document.getElementById('enemy-life-fill').style.width = `${lifePercentage}%`;
-  document.getElementById('enemy-life-text').textContent = `${Math.max(0, Math.floor(enemy.currentLife))}/${Math.floor(
-    enemy.life,
-  )}`;
+  document.getElementById('enemy-life-text').textContent = `${formatNumber(
+    Math.max(0, Math.floor(enemy.currentLife)),
+  )}/${formatNumber(Math.floor(enemy.life))}`;
 
   // Main stats
   const dmg = document.getElementById('enemy-damage-value');
-  if (dmg) dmg.textContent = Math.floor(enemy.damage);
+  if (dmg) dmg.textContent = formatNumber(Math.floor(enemy.damage));
   const fireDmg = document.getElementById('enemy-fire-damage-value');
-  if (fireDmg) fireDmg.textContent = Math.floor(enemy.fireDamage || 0);
+  if (fireDmg) fireDmg.textContent = formatNumber(Math.floor(enemy.fireDamage || 0));
   const coldDmg = document.getElementById('enemy-cold-damage-value');
-  if (coldDmg) coldDmg.textContent = Math.floor(enemy.coldDamage || 0);
+  if (coldDmg) coldDmg.textContent = formatNumber(Math.floor(enemy.coldDamage || 0));
   const airDmg = document.getElementById('enemy-air-damage-value');
-  if (airDmg) airDmg.textContent = Math.floor(enemy.airDamage || 0);
+  if (airDmg) airDmg.textContent = formatNumber(Math.floor(enemy.airDamage || 0));
   const earthDmg = document.getElementById('enemy-earth-damage-value');
-  if (earthDmg) earthDmg.textContent = Math.floor(enemy.earthDamage || 0);
+  if (earthDmg) earthDmg.textContent = formatNumber(Math.floor(enemy.earthDamage || 0));
   const lightningDmg = document.getElementById('enemy-lightning-damage-value');
-  if (lightningDmg) lightningDmg.textContent = Math.floor(enemy.lightningDamage || 0);
+  if (lightningDmg) lightningDmg.textContent = formatNumber(Math.floor(enemy.lightningDamage || 0));
   const waterDmg = document.getElementById('enemy-water-damage-value');
-  if (waterDmg) waterDmg.textContent = Math.floor(enemy.waterDamage || 0);
+  if (waterDmg) waterDmg.textContent = formatNumber(Math.floor(enemy.waterDamage || 0));
 
   const armor = document.getElementById('enemy-armor-value');
   if (armor) {
   // Use PoE2 formula: reduction = armor / (armor + 10 * damage)
     const reduction = calculateArmorReduction(enemy.armor, hero.stats.damage);
-    armor.textContent = Math.floor(enemy.armor || 0) + ` (${Math.floor(reduction)}%)`;
+    armor.textContent = `${formatNumber(Math.floor(enemy.armor || 0))} (${Math.floor(reduction)}%)`;
   }
   const evasion = document.getElementById('enemy-evasion-value');
   if (evasion) {
     const reduction = calculateEvasionChance(enemy.evasion, hero.stats.attackRating);
-    evasion.textContent = Math.floor(enemy.evasion || 0) + ` (${Math.floor(reduction)}%)`;
+    evasion.textContent = `${formatNumber(Math.floor(enemy.evasion || 0))} (${Math.floor(reduction)}%)`;
   }
   const atkRating = document.getElementById('enemy-attack-rating-value');
   if (atkRating) {
     // Show enemy attack rating and their hit chance against the player
     const hitChance = calculateHitChance(enemy.attackRating, hero.stats.evasion);
-    atkRating.textContent = Math.floor(enemy.attackRating || 0) + ` (${Math.floor(hitChance)}%)`;
+    atkRating.textContent = `${formatNumber(Math.floor(enemy.attackRating || 0))} (${Math.floor(hitChance)}%)`;
   }
   const atkSpeed = document.getElementById('enemy-attack-speed-value');
-  if (atkSpeed) atkSpeed.textContent = (enemy.attackSpeed || 0).toFixed(2);
+  if (atkSpeed) atkSpeed.textContent = formatNumber((enemy.attackSpeed || 0).toFixed(2));
   const fireRes = document.getElementById('enemy-fire-resistance-value');
-  if (fireRes) fireRes.textContent = Math.floor(enemy.fireResistance || 0);
+  if (fireRes) fireRes.textContent = formatNumber(Math.floor(enemy.fireResistance || 0));
   const coldRes = document.getElementById('enemy-cold-resistance-value');
-  if (coldRes) coldRes.textContent = Math.floor(enemy.coldResistance || 0);
+  if (coldRes) coldRes.textContent = formatNumber(Math.floor(enemy.coldResistance || 0));
   const airRes = document.getElementById('enemy-air-resistance-value');
-  if (airRes) airRes.textContent = Math.floor(enemy.airResistance || 0);
+  if (airRes) airRes.textContent = formatNumber(Math.floor(enemy.airResistance || 0));
   const earthRes = document.getElementById('enemy-earth-resistance-value');
-  if (earthRes) earthRes.textContent = Math.floor(enemy.earthResistance || 0);
+  if (earthRes) earthRes.textContent = formatNumber(Math.floor(enemy.earthResistance || 0));
   const lightningRes = document.getElementById('enemy-lightning-resistance-value');
-  if (lightningRes) lightningRes.textContent = Math.floor(enemy.lightningResistance || 0);
+  if (lightningRes) lightningRes.textContent = formatNumber(Math.floor(enemy.lightningResistance || 0));
   const waterRes = document.getElementById('enemy-water-resistance-value');
-  if (waterRes) waterRes.textContent = Math.floor(enemy.waterResistance || 0);
+  if (waterRes) waterRes.textContent = formatNumber(Math.floor(enemy.waterResistance || 0));
 
   setEnemyName();
   if (game.fightMode === 'explore') {


### PR DESCRIPTION
## Summary
- add `formatNumber` helper
- use `formatNumber` across UI to show resources, HP/MP bars and enemy stats
- apply formatting to stats, training data and quests
- show numbers with commas in buildings, prestige bonuses and statistics

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68823c4be5708331a0f0a6697caca9b6