### PR TITLE
Add sandbox and disable remote module

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -25,6 +25,8 @@ function createWindow() {
       webSecurity: true,
       allowRunningInsecureContent: false,
       experimentalFeatures: false,
+      sandbox: true,
+      enableRemoteModule: false,
     },
   });
 


### PR DESCRIPTION
## Summary
- enable Electron sandboxing
- explicitly disable the remote module

## Testing
- `pnpm lint` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_6883afeb707c83319e77eb15be8755ac