### PR TITLE
Fix boss reset reroll

### DIFF
--- a/src/crystalShop.js
+++ b/src/crystalShop.js
@@ -6,7 +6,9 @@ import {
   updateSkillTreeValues,
   showConfirmDialog,
   showToast,
+  updateStageUI,
 } from './ui/ui.js';
+import { selectBoss } from './ui/bossUi.js';
 import { handleSavedData } from './functions.js';
 import { updateStatsAndAttributesUI } from './ui/statsAndAttributesUi.js';
 import { createModal } from './ui/modal.js';
@@ -226,6 +228,8 @@ export default class CrystalShop {
       if (!confirmed) return;
       hero.crystals -= cost;
       hero.bossLevel = 1;
+      selectBoss();
+      updateStageUI();
       showToast('Boss level has been reset to 1.', 'success');
     }
     updateResources();


### PR DESCRIPTION
## Summary
- reroll boss when reset arena level crystal is bought

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68880f7cf6188331a84ae1332bd0e2b1