### PR TITLE
Update stage skip option after upgrade

### DIFF
--- a/src/crystalShop.js
+++ b/src/crystalShop.js
@@ -542,6 +542,7 @@ export default class CrystalShop {
       }
       await this._bulkPurchase(stat, config, qty);
       if (stat === 'startingStage') options.updateStartingStageOption();
+      if (stat === 'stageSkip') options.updateStageSkipOption();
       return;
     }
 


### PR DESCRIPTION
## Summary
- update options UI when stage skip upgrade is purchased

## Testing
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888c97303a4833183d7c227f0b9ab95