### PR TITLE
Apply scaleDownFlat to all skill percent bonuses

### DIFF
--- a/src/constants/skills/berserkerSkills.js
+++ b/src/constants/skills/berserkerSkills.js
@@ -1,4 +1,5 @@
 import { DEFAULT_MAX_SKILL_LEVEL, SKILL_LEVEL_TIERS } from '../../skillTree.js';
+import { scaleDownFlat } from '../../common.js';
 
 // Berserker skills extracted from skills.js
 export const BERSERKER_SKILLS = {
@@ -14,7 +15,7 @@ export const BERSERKER_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       damage: level * 2,
-      damagePercent: level * 2,
+      damagePercent: 2 * scaleDownFlat(level),
       lifePerHit: level * -0.4,
     }),
   },
@@ -28,7 +29,7 @@ export const BERSERKER_SKILLS = {
     maxLevel: () => 200,
     effect: (level) => ({
       armor: level * 4,
-      armorPercent: level * 2,
+      armorPercent: 2 * scaleDownFlat(level),
     }),
   },
 
@@ -45,7 +46,7 @@ export const BERSERKER_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       damage: level * 3,
-      damagePercent: level * 4,
+      damagePercent: 4 * scaleDownFlat(level),
       lifePerHit: level * -1,
     }),
   },
@@ -61,7 +62,7 @@ export const BERSERKER_SKILLS = {
     description: () => 'Boosts damage and attack speed temporarily.',
     maxLevel: () => 100,
     effect: (level) => ({
-      damagePercent: level * 0.5,
+      damagePercent: 0.5 * scaleDownFlat(level),
       attackSpeed: level * 0.005,
       lifeSteal: Math.min(level * 0.01, 4),
     }),
@@ -78,8 +79,8 @@ export const BERSERKER_SKILLS = {
     description: () => 'Greatly increases damage but lowers defense.',
     maxLevel: () => 200,
     effect: (level) => ({
-      fireDamagePercent: level * 3,
-      airDamagePercent: level * 3,
+      fireDamagePercent: 3 * scaleDownFlat(level),
+      airDamagePercent: 3 * scaleDownFlat(level),
       doubleDamageChance: Math.min(level * 0.2, 20),
     }),
   },
@@ -109,8 +110,8 @@ export const BERSERKER_SKILLS = {
     description: () => 'Smashes the ground, dealing earth damage.',
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
-      damagePercent: level * 5,
-      earthDamagePercent: level * 10,
+      damagePercent: 5 * scaleDownFlat(level),
+      earthDamagePercent: 10 * scaleDownFlat(level),
     }),
   },
   rageMastery: {
@@ -125,8 +126,8 @@ export const BERSERKER_SKILLS = {
       critChance: Math.min(level * 0.05, 20),
       critDamage: Math.min(level * 0.005, 3),
       doubleDamageChance: Math.min(level * 0.1, 20),
-      attackRatingPercent: level * 5,
-      lifePercent: level * -0.15,
+      attackRatingPercent: 5 * scaleDownFlat(level),
+      lifePercent: -0.15 * scaleDownFlat(level),
     }),
   },
 
@@ -145,7 +146,7 @@ export const BERSERKER_SKILLS = {
     effect: (level) => ({
       attackSpeed: level * 0.002,
       lifeSteal: level * 0.01,
-      lifePercent: level * 0.25,
+      lifePercent: 0.25 * scaleDownFlat(level),
     }),
   },
 
@@ -160,7 +161,7 @@ export const BERSERKER_SKILLS = {
     description: () => 'Increases damage and restores resources.',
     maxLevel: () => 400,
     effect: (level) => ({
-      damagePercent: level * 2,
+      damagePercent: 2 * scaleDownFlat(level),
       manaPerHit: level * 0.1,
       lifePerHit: level * 1,
     }),
@@ -176,8 +177,8 @@ export const BERSERKER_SKILLS = {
     effect: (level) => ({
       resurrectionChance: level * 0.1,
       lifeRegen: level * 1,
-      lifeRegenPercent: level * 0.75,
-      armorPercent: level * 3,
+      lifeRegenPercent: 0.75 * scaleDownFlat(level),
+      armorPercent: 3 * scaleDownFlat(level),
     }),
   },
 
@@ -191,10 +192,10 @@ export const BERSERKER_SKILLS = {
     description: () => 'Significantly increases all combat stats.',
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
-      strengthPercent: level * 2.5,
+      strengthPercent: 2.5 * scaleDownFlat(level),
       critChance: Math.min(level * 0.05, 20),
       attackSpeed: level * 0.002,
-      damagePercent: level * 1,
+      damagePercent: scaleDownFlat(level),
     }),
   },
 };

--- a/src/constants/skills/druidSkills.js
+++ b/src/constants/skills/druidSkills.js
@@ -1,4 +1,5 @@
 import { DEFAULT_MAX_SKILL_LEVEL, SKILL_LEVEL_TIERS } from '../../skillTree.js';
+import { scaleDownFlat } from '../../common.js';
 
 // Druid skills
 export const DRUID_SKILLS = {
@@ -37,7 +38,7 @@ export const DRUID_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       armor: level * 3,
-      armorPercent: level * 2,
+      armorPercent: 2 * scaleDownFlat(level),
       lifeRegen: level * 1,
     }),
   },
@@ -51,8 +52,8 @@ export const DRUID_SKILLS = {
     maxLevel: () => 200,
     effect: (level) => ({
       vitality: level * 2,
-      lifePercent: level * 0.25,
-      lifeRegenOfTotalPercent: Math.min(level * 0.005, 1),
+      lifePercent: 0.25 * scaleDownFlat(level),
+      lifeRegenOfTotalPercent: Math.min(scaleDownFlat(level) * 0.005, 1),
     }),
   },
 
@@ -70,7 +71,7 @@ export const DRUID_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       lifeRegen: level * 4,
-      lifeRegenPercent: level * 0.5,
+      lifeRegenPercent: 0.5 * scaleDownFlat(level),
     }),
   },
   entanglingRoots: {
@@ -85,7 +86,7 @@ export const DRUID_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       earthDamage: level * 5,
-      earthDamagePercent: level * 5,
+      earthDamagePercent: 5 * scaleDownFlat(level),
     }),
   },
 
@@ -121,8 +122,8 @@ export const DRUID_SKILLS = {
     description: () => 'Increases life and life regeneration.',
     maxLevel: () => 200,
     effect: (level) => ({
-      lifePercent: level * 0.5,
-      lifeRegenOfTotalPercent: Math.min(level * 0.005, 1),
+      lifePercent: 0.5 * scaleDownFlat(level),
+      lifeRegenOfTotalPercent: Math.min(scaleDownFlat(level) * 0.005, 1),
     }),
   },
 
@@ -139,9 +140,9 @@ export const DRUID_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       airDamage: level * 4,
-      airDamagePercent: level * 6,
+      airDamagePercent: 6 * scaleDownFlat(level),
       coldDamage: level * 4,
-      coldDamagePercent: level * 6,
+      coldDamagePercent: 6 * scaleDownFlat(level),
     }),
   },
   stoneform: {
@@ -157,8 +158,8 @@ export const DRUID_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       armor: level * 4,
-      armorPercent: level * 5,
-      earthDamagePercent: level * 2,
+      armorPercent: 5 * scaleDownFlat(level),
+      earthDamagePercent: 2 * scaleDownFlat(level),
     }),
   },
 
@@ -188,9 +189,9 @@ export const DRUID_SKILLS = {
     description: () => 'Empowers you under the moon, boosting elemental damage.',
     maxLevel: () => 300,
     effect: (level) => ({
-      coldDamagePercent: level * 2,
+      coldDamagePercent: 2 * scaleDownFlat(level),
       coldDamage: level * 4,
-      airDamagePercent: level * 2,
+      airDamagePercent: 2 * scaleDownFlat(level),
       airDamage: level * 4,
     }),
   },
@@ -208,10 +209,10 @@ export const DRUID_SKILLS = {
     description: () => 'Embrace the earth for defense and regeneration.',
     maxLevel: () => 500,
     effect: (level) => ({
-      armorPercent: level * 2,
-      lifeRegenPercent: level * 0.5,
+      armorPercent: 2 * scaleDownFlat(level),
+      lifeRegenPercent: 0.5 * scaleDownFlat(level),
       lifeRegen: level * 2,
-      lifeRegenOfTotalPercent: level * 0.01,
+      lifeRegenOfTotalPercent: scaleDownFlat(level) * 0.01,
     }),
   },
   wrathOfNature: {
@@ -223,9 +224,9 @@ export const DRUID_SKILLS = {
     description: () => 'Nature fights with you, increasing all stats.',
     maxLevel: () => 500,
     effect: (level) => ({
-      damagePercent: level * 2.5,
-      vitalityPercent: level * 1,
-      elementalDamagePercent: level * 1,
+      damagePercent: 2.5 * scaleDownFlat(level),
+      vitalityPercent: scaleDownFlat(level),
+      elementalDamagePercent: scaleDownFlat(level),
     }),
   },
 
@@ -240,10 +241,10 @@ export const DRUID_SKILLS = {
     maxLevel: () => 100,
     effect: (level) => ({
       vitality: level * 3,
-      vitalityPercent: level * 3,
+      vitalityPercent: 3 * scaleDownFlat(level),
       strength: level * 4,
-      damagePercent: level * 2,
-      lifePercent: level * 2,
+      damagePercent: 2 * scaleDownFlat(level),
+      lifePercent: 2 * scaleDownFlat(level),
     }),
   },
 };

--- a/src/constants/skills/elementalistSkills.js
+++ b/src/constants/skills/elementalistSkills.js
@@ -1,4 +1,5 @@
 import { DEFAULT_MAX_SKILL_LEVEL, SKILL_LEVEL_TIERS } from '../../skillTree.js';
+import { scaleDownFlat } from '../../common.js';
 
 // Elementalist skills extracted from skills.js
 export const ELEMENTALIST_SKILLS = {
@@ -15,7 +16,7 @@ export const ELEMENTALIST_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       fireDamage: level * 2,
-      fireDamagePercent: level * 5,
+      fireDamagePercent: 5 * scaleDownFlat(level),
     }),
   },
   frostArmor: {
@@ -31,8 +32,8 @@ export const ELEMENTALIST_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       armor: level * 4,
-      armorPercent: level * 3,
-      coldDamagePercent: level * 2,
+      armorPercent: 3 * scaleDownFlat(level),
+      coldDamagePercent: 2 * scaleDownFlat(level),
     }),
   },
 
@@ -45,10 +46,10 @@ export const ELEMENTALIST_SKILLS = {
     description: () => 'Increases mana and mana regeneration',
     maxLevel: () => 1000,
     effect: (level) => ({
-      manaPercent: level * 2,
+      manaPercent: 2 * scaleDownFlat(level),
       manaRegen: level * 0.1,
-      manaRegenPercent: level * 0.5,
-      wisdomPercent: level * 0.5,
+      manaRegenPercent: 0.5 * scaleDownFlat(level),
+      wisdomPercent: 0.5 * scaleDownFlat(level),
       wisdom: level * 2,
     }),
   },
@@ -66,8 +67,8 @@ export const ELEMENTALIST_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       lightningDamage: level * 5,
-      lightningDamagePercent: level * 6,
-      airDamagePercent: level * 2,
+      lightningDamagePercent: 6 * scaleDownFlat(level),
+      airDamagePercent: 2 * scaleDownFlat(level),
     }),
   },
   elementalMastery: {
@@ -79,7 +80,7 @@ export const ELEMENTALIST_SKILLS = {
     description: () => 'Increases all elemental damage.',
     maxLevel: () => 200,
     effect: (level) => ({
-      elementalDamagePercent: level * 1,
+      elementalDamagePercent: scaleDownFlat(level),
     }),
   },
 
@@ -96,10 +97,10 @@ export const ELEMENTALIST_SKILLS = {
     description: () => 'Summons a blizzard, covering the battlefield in frost.',
     maxLevel: () => 100,
     effect: (level) => ({
-      coldDamagePercent: level * 3,
-      airDamagePercent: level * 3,
-      waterDamagePercent: level * 3,
-      lightningDamagePercent: level * 3,
+      coldDamagePercent: 3 * scaleDownFlat(level),
+      airDamagePercent: 3 * scaleDownFlat(level),
+      waterDamagePercent: 3 * scaleDownFlat(level),
+      lightningDamagePercent: 3 * scaleDownFlat(level),
       coldDamage: level * 3,
       airDamage: level * 3,
       waterDamage: level * 3,
@@ -119,7 +120,7 @@ export const ELEMENTALIST_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       reflectFireDamage: level * 18,
-      fireDamagePercent: level * 2.5,
+      fireDamagePercent: 2.5 * scaleDownFlat(level),
     }),
   },
   arcaneWisdom: {
@@ -131,10 +132,10 @@ export const ELEMENTALIST_SKILLS = {
     description: () => 'Increases mana and mana regeneration.',
     maxLevel: () => 200,
     effect: (level) => ({
-      manaPercent: level * 1.5,
+      manaPercent: 1.5 * scaleDownFlat(level),
       manaRegen: level * 0.2,
-      manaRegenPercent: level * 0.5,
-      manaRegenOfTotalPercent: Math.min(level * 0.005, 1),
+      manaRegenPercent: 0.5 * scaleDownFlat(level),
+      manaRegenOfTotalPercent: Math.min(scaleDownFlat(level) * 0.005, 1),
     }),
   },
 
@@ -151,7 +152,7 @@ export const ELEMENTALIST_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       elementalDamage: level * 3,
-      elementalDamagePercent: level * 1,
+      elementalDamagePercent: scaleDownFlat(level),
     }),
   },
   elementalAffinity: {
@@ -164,8 +165,8 @@ export const ELEMENTALIST_SKILLS = {
     maxLevel: () => 1000,
     effect: (level) => ({
       elementalDamage: level * 0.5,
-      elementalDamagePercent: level * 0.5,
-      intelligencePercent: level * 0.5,
+      elementalDamagePercent: 0.5 * scaleDownFlat(level),
+      intelligencePercent: 0.5 * scaleDownFlat(level),
     }),
   },
 
@@ -183,7 +184,7 @@ export const ELEMENTALIST_SKILLS = {
     maxLevel: () => 200,
     effect: (level) => ({
       attackRating: level * 5,
-      attackRatingPercent: level * 5,
+      attackRatingPercent: 5 * scaleDownFlat(level),
       lifePerHit: level * 4,
       manaPerHit: level * 0.5,
       attackSpeed: level * 0.01,
@@ -201,10 +202,10 @@ export const ELEMENTALIST_SKILLS = {
     description: () => 'Boosts elemental damage.',
     maxLevel: () => 600,
     effect: (level) => ({
-      fireDamagePercent: level * 2,
-      coldDamagePercent: level * 2,
-      airDamagePercent: level * 2,
-      lightningDamagePercent: level * 2,
+      fireDamagePercent: 2 * scaleDownFlat(level),
+      coldDamagePercent: 2 * scaleDownFlat(level),
+      airDamagePercent: 2 * scaleDownFlat(level),
+      lightningDamagePercent: 2 * scaleDownFlat(level),
     }),
   },
   primordialControl: {
@@ -216,10 +217,10 @@ export const ELEMENTALIST_SKILLS = {
     description: () => 'Grants control over elemental forces, increasing all stats.',
     maxLevel: () => 5000,
     effect: (level) => ({
-      earthDamagePercent: level * 1.5,
+      earthDamagePercent: 1.5 * scaleDownFlat(level),
       vitality: level * 5,
-      vitalityPercent: level * 2,
-      wisdomPercent: level * 2,
+      vitalityPercent: 2 * scaleDownFlat(level),
+      wisdomPercent: 2 * scaleDownFlat(level),
     }),
   },
 
@@ -233,11 +234,11 @@ export const ELEMENTALIST_SKILLS = {
     description: () => 'Transforms the caster into a being of pure elemental power.',
     maxLevel: () => 100,
     effect: (level) => ({
-      elementalDamagePercent: level * 3,
+      elementalDamagePercent: 3 * scaleDownFlat(level),
       elementalDamage: level * 2,
       allResistance: level * 0.25,
       perseverance: level * 5,
-      perseverancePercent: level * 2,
+      perseverancePercent: 2 * scaleDownFlat(level),
     }),
   },
 };

--- a/src/constants/skills/paladinSkills.js
+++ b/src/constants/skills/paladinSkills.js
@@ -1,4 +1,5 @@
 import { DEFAULT_MAX_SKILL_LEVEL, SKILL_LEVEL_TIERS } from '../../skillTree.js';
+import { scaleDownFlat } from '../../common.js';
 
 // Paladin skills extracted from skills.js
 export const PALADIN_SKILLS = {
@@ -15,7 +16,7 @@ export const PALADIN_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       life: level * 5,
-      lifePercent: Math.min(level * 0.1, 5),
+      lifePercent: Math.min(scaleDownFlat(level) * 0.1, 5),
     }),
   },
   smite: {
@@ -29,8 +30,8 @@ export const PALADIN_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       damage: level * 1,
-      damagePercent: level * 1,
-      fireDamagePercent: level * 2,
+      damagePercent: scaleDownFlat(level),
+      fireDamagePercent: 2 * scaleDownFlat(level),
     }),
   },
   shieldBash: {
@@ -45,7 +46,7 @@ export const PALADIN_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       damage: level * 2,
-      damagePercent: level * 3,
+      damagePercent: 3 * scaleDownFlat(level),
     }),
   },
   divineProtection: {
@@ -57,9 +58,9 @@ export const PALADIN_SKILLS = {
     description: () => 'Greatly increases armor and block chance.',
     maxLevel: () => 200,
     effect: (level) => ({
-      armorPercent: level * 2,
+      armorPercent: 2 * scaleDownFlat(level),
       thornsDamage: level * 1,
-      thornsDamagePercent: level * 0.5,
+      thornsDamagePercent: 0.5 * scaleDownFlat(level),
     }),
   },
 
@@ -76,9 +77,9 @@ export const PALADIN_SKILLS = {
     description: () => 'Blesses the ground, dealing holy damage to enemies.',
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
-      fireDamagePercent: level * 4,
-      coldDamagePercent: level * 4,
-      lightningDamagePercent: level * 4,
+      fireDamagePercent: 4 * scaleDownFlat(level),
+      coldDamagePercent: 4 * scaleDownFlat(level),
+      lightningDamagePercent: 4 * scaleDownFlat(level),
     }),
   },
   greaterHealing: {
@@ -93,7 +94,7 @@ export const PALADIN_SKILLS = {
     maxLevel: () => Infinity,
     effect: (level) => ({
       life: level * 8,
-      lifePercent: Math.min(level * 0.25, 20),
+      lifePercent: Math.min(scaleDownFlat(level) * 0.25, 20),
     }),
   },
 
@@ -111,7 +112,7 @@ export const PALADIN_SKILLS = {
     maxLevel: () => 200,
     effect: (level) => ({
       armor: level * 4,
-      armorPercent: level * 6,
+      armorPercent: 6 * scaleDownFlat(level),
       blockChance: level * 0.2,
     }),
   },
@@ -125,8 +126,8 @@ export const PALADIN_SKILLS = {
     maxLevel: () => 500,
     effect: (level) => ({
       life: level * 5,
-      lifePercent: level * 0.6,
-      armorPercent: level * 1,
+      lifePercent: 0.6 * scaleDownFlat(level),
+      armorPercent: scaleDownFlat(level),
       allResistance: Math.min(level * 0.25, 30),
     }),
   },
@@ -143,10 +144,10 @@ export const PALADIN_SKILLS = {
     description: () => 'Calls down holy energy to smite enemies.',
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
-      damagePercent: level * 2,
+      damagePercent: 2 * scaleDownFlat(level),
       lightningDamage: level * 8,
-      lightningDamagePercent: level * 5,
-      airDamagePercent: level * 3,
+      lightningDamagePercent: 5 * scaleDownFlat(level),
+      airDamagePercent: 3 * scaleDownFlat(level),
     }),
   },
   beaconOfFaith: {
@@ -159,8 +160,8 @@ export const PALADIN_SKILLS = {
     maxLevel: () => 500,
     effect: (level) => ({
       lifeRegen: level * 1,
-      lifeRegenPercent: level * 0.5,
-      lifeRegenOfTotalPercent: Math.min(level * 0.1, 1),
+      lifeRegenPercent: 0.5 * scaleDownFlat(level),
+      lifeRegenOfTotalPercent: Math.min(scaleDownFlat(level) * 0.1, 1),
     }),
   },
 
@@ -178,7 +179,7 @@ export const PALADIN_SKILLS = {
     maxLevel: () => 500,
     effect: (level) => ({
       vitality: level * 3,
-      vitalityPercent: level * 0.5,
+      vitalityPercent: 0.5 * scaleDownFlat(level),
       resurrectionChance: level * 0.1,
     }),
   },
@@ -194,7 +195,7 @@ export const PALADIN_SKILLS = {
     description: () => 'Unleashes divine energy to increase damage and healing.',
     maxLevel: () => 400,
     effect: (level) => ({
-      damagePercent: level * 2,
+      damagePercent: 2 * scaleDownFlat(level),
       lifePerHit: level * 2,
     }),
   },
@@ -209,9 +210,9 @@ export const PALADIN_SKILLS = {
     effect: (level) => ({
       resurrectionChance: level * 0.1,
       lifeRegen: level * 2,
-      lifeRegenPercent: level * 0.5,
+      lifeRegenPercent: 0.5 * scaleDownFlat(level),
       manaRegen: level * 0.5,
-      manaRegenPercent: level * 1,
+      manaRegenPercent: scaleDownFlat(level),
     }),
   },
 
@@ -225,12 +226,12 @@ export const PALADIN_SKILLS = {
     description: () => 'Grants significant bonuses to all attributes.',
     maxLevel: () => 400,
     effect: (level) => ({
-      elementalDamagePercent: level * 0.75,
+      elementalDamagePercent: 0.75 * scaleDownFlat(level),
       endurance: level * 3,
-      endurancePercent: level * 2,
+      endurancePercent: 2 * scaleDownFlat(level),
       vitality: level * 3,
-      vitalityPercent: level * 2,
-      attackRatingPercent: level * 6,
+      vitalityPercent: 2 * scaleDownFlat(level),
+      attackRatingPercent: 6 * scaleDownFlat(level),
     }),
   },
 };

--- a/src/constants/skills/rogueSkills.js
+++ b/src/constants/skills/rogueSkills.js
@@ -1,4 +1,5 @@
 import { DEFAULT_MAX_SKILL_LEVEL, SKILL_LEVEL_TIERS } from '../../skillTree.js';
+import { scaleDownFlat } from '../../common.js';
 
 // Rogue skills extracted from skills.js
 export const ROGUE_SKILLS = {
@@ -12,7 +13,7 @@ export const ROGUE_SKILLS = {
     description: () => 'A quick dance from the shadows, increasing your damage.',
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
-      damagePercent: level * 0.75,
+      damagePercent: 0.75 * scaleDownFlat(level),
       critChance: level * 0.05,
       agility: level * 3,
     }),
@@ -31,7 +32,7 @@ export const ROGUE_SKILLS = {
     effect: (level) => ({
       blockChance: Math.min(level * 0.05, 25),
       dexterity: level * 4,
-      dexterityPercent: level * 2,
+      dexterityPercent: 2 * scaleDownFlat(level),
     }),
   },
 
@@ -47,9 +48,9 @@ export const ROGUE_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       damage: level * 2,
-      damagePercent: level * 2,
-      earthDamagePercent: level * 2,
-      waterDamagePercent: level * 1,
+      damagePercent: 2 * scaleDownFlat(level),
+      earthDamagePercent: 2 * scaleDownFlat(level),
+      waterDamagePercent: scaleDownFlat(level),
     }),
   },
   shadowForm: {
@@ -67,7 +68,7 @@ export const ROGUE_SKILLS = {
       critChance: Math.min(level * 0.05, 20),
       critDamage: Math.min(level * 0.002, 3),
       lifeSteal: Math.min(level * 0.01, 4),
-      agilityPercent: level * 1,
+      agilityPercent: scaleDownFlat(level),
     }),
   },
 
@@ -84,7 +85,7 @@ export const ROGUE_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       damage: level * 5,
-      damagePercent: level * 8,
+      damagePercent: 8 * scaleDownFlat(level),
     }),
   },
   precision: {
@@ -97,8 +98,8 @@ export const ROGUE_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       dexterity: level * 5,
-      dexterityPercent: level * 2,
-      agilityPercent: level * 2,
+      dexterityPercent: 2 * scaleDownFlat(level),
+      agilityPercent: 2 * scaleDownFlat(level),
     }),
   },
 
@@ -114,7 +115,7 @@ export const ROGUE_SKILLS = {
     description: () => 'A devastating attack from behind, dealing massive damage and stealing resources.',
     maxLevel: () => 100,
     effect: (level) => ({
-      damagePercent: level * 4,
+      damagePercent: 4 * scaleDownFlat(level),
       lifePerHit: level * 6,
       manaPerHit: level * 0.6,
     }),
@@ -149,9 +150,9 @@ export const ROGUE_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       damage: level * 3,
-      damagePercent: level * 3,
-      coldDamagePercent: level * 5,
-      airDamagePercent: level * 5,
+      damagePercent: 3 * scaleDownFlat(level),
+      coldDamagePercent: 5 * scaleDownFlat(level),
+      airDamagePercent: 5 * scaleDownFlat(level),
     }),
   },
 
@@ -167,7 +168,7 @@ export const ROGUE_SKILLS = {
       critChance: level * 0.05,
       critDamage: level * 0.0025,
       attackRating: level * 15,
-      attackRatingPercent: level * 0.5,
+      attackRatingPercent: 0.5 * scaleDownFlat(level),
     }),
   },
 
@@ -181,11 +182,11 @@ export const ROGUE_SKILLS = {
     description: () => 'Greatly increases attributes and gold gains.',
     maxLevel: () => 500,
     effect: (level) => ({
-      damagePercent: level * 0.5,
-      dexterityPercent: level * 3,
-      agilityPercent: level * 2,
-      wisdomPercent: level * 1,
-      bonusGoldPercent: level * 0.25,
+      damagePercent: 0.5 * scaleDownFlat(level),
+      dexterityPercent: 3 * scaleDownFlat(level),
+      agilityPercent: 2 * scaleDownFlat(level),
+      wisdomPercent: scaleDownFlat(level),
+      bonusGoldPercent: 0.25 * scaleDownFlat(level),
     }),
   },
 };

--- a/src/constants/skills/vampireSkills.js
+++ b/src/constants/skills/vampireSkills.js
@@ -1,4 +1,5 @@
 import { DEFAULT_MAX_SKILL_LEVEL, SKILL_LEVEL_TIERS } from '../../skillTree.js';
+import { scaleDownFlat } from '../../common.js';
 
 // Vampire skills extracted from skills.js
 export const VAMPIRE_SKILLS = {
@@ -15,7 +16,7 @@ export const VAMPIRE_SKILLS = {
     effect: (level) => ({
       lifePerHit: level * 0.5,
       damage: level * 1,
-      damagePercent: level * 1,
+      damagePercent: scaleDownFlat(level),
     }),
   },
   nightStalker: {
@@ -27,7 +28,7 @@ export const VAMPIRE_SKILLS = {
     description: () => 'Increases damage at night.',
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
-      damagePercent: level * 0.5,
+      damagePercent: 0.5 * scaleDownFlat(level),
       agility: level * 4,
     }),
   },
@@ -45,7 +46,7 @@ export const VAMPIRE_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       damage: level * 2,
-      damagePercent: level * 2,
+      damagePercent: 2 * scaleDownFlat(level),
       lifePerHit: level * 2,
     }),
   },
@@ -63,7 +64,7 @@ export const VAMPIRE_SKILLS = {
     effect: (level) => ({
       lifeSteal: level * 0.02,
       attackRating: level * 5,
-      attackRatingPercent: level * 2,
+      attackRatingPercent: 2 * scaleDownFlat(level),
     }),
   },
 
@@ -80,7 +81,7 @@ export const VAMPIRE_SKILLS = {
     maxLevel: () => 100,
     effect: (level) => ({
       earthDamage: level * 4,
-      earthDamagePercent: level * 5,
+      earthDamagePercent: 5 * scaleDownFlat(level),
       manaPerHit: level * 0.2,
     }),
   },
@@ -93,8 +94,8 @@ export const VAMPIRE_SKILLS = {
     description: () => 'Increases strength and vitality.',
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
-      strengthPercent: level * 1,
-      vitalityPercent: level * 2,
+      strengthPercent: scaleDownFlat(level),
+      vitalityPercent: 2 * scaleDownFlat(level),
     }),
   },
 
@@ -110,7 +111,7 @@ export const VAMPIRE_SKILLS = {
     description: () => 'Unleashes a burst of crimson energy, greatly damaging the enemy at the cost of life.',
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
-      damagePercent: level * 10,
+      damagePercent: 10 * scaleDownFlat(level),
       lifePerHit: level * -1,
     }),
   },
@@ -129,7 +130,7 @@ export const VAMPIRE_SKILLS = {
     maxLevel: () => 400,
     effect: (level) => ({
       life: level * 10,
-      lifePercent: level * 1,
+      lifePercent: scaleDownFlat(level),
     }),
   },
 
@@ -144,7 +145,7 @@ export const VAMPIRE_SKILLS = {
     description: () => 'Increases life steal and damage.',
     maxLevel: () => 200,
     effect: (level) => ({
-      damagePercent: level * 2,
+      damagePercent: 2 * scaleDownFlat(level),
       lifePerHit: level * 2,
     }),
   },
@@ -157,9 +158,9 @@ export const VAMPIRE_SKILLS = {
     description: () => 'Increases life greatly, and strength mildly.',
     maxLevel: () => 100,
     effect: (level) => ({
-      lifePercent: level * 0.5,
-      strengthPercent: level * 0.38,
-      vitalityPercent: level * 2,
+      lifePercent: 0.5 * scaleDownFlat(level),
+      strengthPercent: 0.38 * scaleDownFlat(level),
+      vitalityPercent: 2 * scaleDownFlat(level),
     }),
   },
 
@@ -173,10 +174,10 @@ export const VAMPIRE_SKILLS = {
     description: () => 'Greatly increases all attributes and gives resurrection.',
     maxLevel: () => 500,
     effect: (level) => ({
-      strengthPercent: level * 1,
-      vitalityPercent: level * 2,
+      strengthPercent: scaleDownFlat(level),
+      vitalityPercent: 2 * scaleDownFlat(level),
       resurrectionChance: level * 0.1,
-      wisdomPercent: level * 1,
+      wisdomPercent: scaleDownFlat(level),
       wisdom: level * 2,
     }),
   },

--- a/src/constants/skills/warriorSkills.js
+++ b/src/constants/skills/warriorSkills.js
@@ -1,4 +1,5 @@
 import { DEFAULT_MAX_SKILL_LEVEL, SKILL_LEVEL_TIERS } from '../../skillTree.js';
+import { scaleDownFlat } from '../../common.js';
 
 // Warrior skills extracted from skills.js
 export const WARRIOR_SKILLS = {
@@ -14,7 +15,7 @@ export const WARRIOR_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       damage: level * 1,
-      damagePercent: level * 1,
+      damagePercent: scaleDownFlat(level),
     }),
   },
   toughness: {
@@ -27,7 +28,7 @@ export const WARRIOR_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       armor: level * 3,
-      armorPercent: level * 2.5,
+      armorPercent: 2.5 * scaleDownFlat(level),
     }),
   },
 
@@ -44,7 +45,7 @@ export const WARRIOR_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       damage: level * 2,
-      damagePercent: level * 5,
+      damagePercent: 5 * scaleDownFlat(level),
     }),
   },
   ironWill: {
@@ -57,7 +58,7 @@ export const WARRIOR_SKILLS = {
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
       vitality: level * 1,
-      vitalityPercent: level * 1,
+      vitalityPercent: scaleDownFlat(level),
       lifeRegen: level * 0.75,
     }),
   },
@@ -75,7 +76,7 @@ export const WARRIOR_SKILLS = {
     description: () => 'Temporarily increases damage',
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
-      damagePercent: level * 2,
+      damagePercent: 2 * scaleDownFlat(level),
     }),
   },
   fortitude: {
@@ -87,9 +88,9 @@ export const WARRIOR_SKILLS = {
     description: () => 'Increases life regeneration',
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
-      lifeRegenOfTotalPercent: Math.min(level * 0.005, 1),
+      lifeRegenOfTotalPercent: Math.min(scaleDownFlat(level) * 0.005, 1),
       lifeRegen: level * 1,
-      lifeRegenPercent: level * 0.5,
+      lifeRegenPercent: 0.5 * scaleDownFlat(level),
     }),
   },
 
@@ -105,7 +106,7 @@ export const WARRIOR_SKILLS = {
     description: () => 'Deals instant damage',
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
-      damagePercent: level * 8,
+      damagePercent: 8 * scaleDownFlat(level),
     }),
   },
 
@@ -122,7 +123,7 @@ export const WARRIOR_SKILLS = {
     description: () => 'Increases armor and block chance temporarily',
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
-      armorPercent: level * 6,
+      armorPercent: 6 * scaleDownFlat(level),
       blockChance: level * 0.1,
     }),
   },
@@ -138,9 +139,9 @@ export const WARRIOR_SKILLS = {
     description: () => 'Gives huge amounts of physical and fire damage',
     maxLevel: () => DEFAULT_MAX_SKILL_LEVEL,
     effect: (level) => ({
-      damagePercent: level * 1,
+      damagePercent: scaleDownFlat(level),
       fireDamage: level * 3,
-      fireDamagePercent: level * 3,
+      fireDamagePercent: 3 * scaleDownFlat(level),
     }),
   },
 
@@ -156,7 +157,7 @@ export const WARRIOR_SKILLS = {
       lifeSteal: level * 0.02,
       attackSpeed: level * 0.01,
       attackRating: level * 6,
-      attackRatingPercent: level * 4,
+      attackRatingPercent: 4 * scaleDownFlat(level),
     }),
   },
 
@@ -170,13 +171,13 @@ export const WARRIOR_SKILLS = {
     description: () => 'Increases all attributes significantly',
     maxLevel: () => 200,
     effect: (level) => ({
-      lifePercent: level * 0.3,
-      damagePercent: level * 0.3,
-      strengthPercent: level * 1.5,
-      vitalityPercent: level * 1.5,
-      agilityPercent: level * 1.5,
-      wisdomPercent: level * 1,
-      endurancePercent: level * 1.5,
+      lifePercent: 0.3 * scaleDownFlat(level),
+      damagePercent: 0.3 * scaleDownFlat(level),
+      strengthPercent: 1.5 * scaleDownFlat(level),
+      vitalityPercent: 1.5 * scaleDownFlat(level),
+      agilityPercent: 1.5 * scaleDownFlat(level),
+      wisdomPercent: scaleDownFlat(level),
+      endurancePercent: 1.5 * scaleDownFlat(level),
     }),
   },
 };


### PR DESCRIPTION
## Summary
- import `scaleDownFlat` in each class skill file
- apply `scaleDownFlat` to percentage-based level scaling across all skills
- run eslint fix

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68880f2fc00c8331bf3dd668b6bbc920