### PR TITLE
Adjust enemy damage balance

### DIFF
--- a/src/constants/enemies/crystal_cave.js
+++ b/src/constants/enemies/crystal_cave.js
@@ -61,6 +61,9 @@ export const CRYSTAL_CAVE_ENEMIES = [
 
     attackSpeed: 1.2,
 
+    damage: 1.5 * getEnemyStatMultiplier(tier),
+    airDamage: 1.5 * getEnemyStatMultiplier(tier),
+
     airResistance: 10,
     fireResistance: 5,
     coldResistance: 5,

--- a/src/constants/enemies/frozen_tundra.js
+++ b/src/constants/enemies/frozen_tundra.js
@@ -10,7 +10,7 @@ export const TUNDRA_ENEMIES = [
     tier: tier,
 
     life: 26 * getEnemyStatMultiplier(tier),
-    damage: 0 * getEnemyStatMultiplier(tier),
+    damage: 1 * getEnemyStatMultiplier(tier),
     attackSpeed: 0.9,
     attackRating: 10 * getEnemyStatMultiplier(tier),
     armor: 9 * getEnemyStatMultiplier(tier),
@@ -19,8 +19,8 @@ export const TUNDRA_ENEMIES = [
     xp: 9 * getEnemyStatMultiplier(tier),
     gold: 7 * getEnemyStatMultiplier(tier),
 
-    airDamage: 3 * getEnemyStatMultiplier(tier),
-    coldDamage: 3 * getEnemyStatMultiplier(tier),
+    airDamage: 1 * getEnemyStatMultiplier(tier),
+    coldDamage: 1 * getEnemyStatMultiplier(tier),
 
     coldResistance: 25,
     fireResistance: 5,
@@ -39,7 +39,7 @@ export const TUNDRA_ENEMIES = [
     tier: tier,
 
     life: 24 * getEnemyStatMultiplier(tier),
-    damage: 4 * getEnemyStatMultiplier(tier),
+    damage: 2 * getEnemyStatMultiplier(tier),
     attackRating: 11 * getEnemyStatMultiplier(tier),
     armor: 7 * getEnemyStatMultiplier(tier),
     evasion: 8 * getEnemyStatMultiplier(tier),
@@ -65,7 +65,7 @@ export const TUNDRA_ENEMIES = [
     tier: tier,
 
     life: 32 * getEnemyStatMultiplier(tier),
-    damage: 3 * getEnemyStatMultiplier(tier),
+    damage: 2 * getEnemyStatMultiplier(tier),
     attackSpeed: 0.95,
     attackRating: 15 * getEnemyStatMultiplier(tier),
     armor: 11 * getEnemyStatMultiplier(tier),
@@ -74,7 +74,7 @@ export const TUNDRA_ENEMIES = [
     xp: 10 * getEnemyStatMultiplier(tier),
     gold: 10 * getEnemyStatMultiplier(tier),
 
-    coldDamage: 2 * getEnemyStatMultiplier(tier),
+    coldDamage: 1.2 * getEnemyStatMultiplier(tier),
 
     coldResistance: 20,
     fireResistance: 5,

--- a/src/constants/enemies/golden_steppe.js
+++ b/src/constants/enemies/golden_steppe.js
@@ -11,6 +11,7 @@ export const GOLDEN_STEPPE_ENEMIES = [
 
     life: 40 * getEnemyStatMultiplier(tier),
     damage: 2 * getEnemyStatMultiplier(tier),
+    earthDamage: 1.2 * getEnemyStatMultiplier(tier),
     armor: 8 * getEnemyStatMultiplier(tier),
 
     gold: 13 * getEnemyStatMultiplier(tier),
@@ -30,6 +31,9 @@ export const GOLDEN_STEPPE_ENEMIES = [
 
     image: '/enemies/aurelius.jpg',
     tier: tier,
+
+    damage: 1.4 * getEnemyStatMultiplier(tier),
+    airDamage: 1.2 * getEnemyStatMultiplier(tier),
 
     fireResistance: 60,
     coldResistance: 25,

--- a/src/constants/enemies/haunted_moor.js
+++ b/src/constants/enemies/haunted_moor.js
@@ -9,14 +9,14 @@ export const HAUNTED_MOOR_ENEMIES = [
     image: '/enemies/banshee.jpg',
     tier: tier,
 
-    damage: 1 * getEnemyStatMultiplier(tier),
+    damage: 1.4 * getEnemyStatMultiplier(tier),
     attackSpeed: 1.1,
     evasion: 11 * getEnemyStatMultiplier(tier),
 
     xp: 5 * getEnemyStatMultiplier(tier),
     gold: 5 * getEnemyStatMultiplier(tier),
 
-    airDamage: 1 * getEnemyStatMultiplier(tier),
+    airDamage: 1.2 * getEnemyStatMultiplier(tier),
 
     fireResistance: 5,
     coldResistance: 10,

--- a/src/constants/enemies/murky_swamp.js
+++ b/src/constants/enemies/murky_swamp.js
@@ -10,7 +10,7 @@ export const SWAMP_ENEMIES = [
     tier: tier,
 
     life: 24 * getEnemyStatMultiplier(tier),
-    damage: 2 * getEnemyStatMultiplier(tier),
+    damage: 1.5 * getEnemyStatMultiplier(tier),
     attackRating: 12 * getEnemyStatMultiplier(tier),
     armor: 8 * getEnemyStatMultiplier(tier),
     evasion: 6 * getEnemyStatMultiplier(tier),
@@ -18,7 +18,7 @@ export const SWAMP_ENEMIES = [
     xp: 8 * getEnemyStatMultiplier(tier),
     gold: 7 * getEnemyStatMultiplier(tier),
 
-    earthDamage: 3 * getEnemyStatMultiplier(tier),
+    earthDamage: 1.5 * getEnemyStatMultiplier(tier),
 
     fireResistance: 5,
     coldResistance: 5,
@@ -65,7 +65,7 @@ export const SWAMP_ENEMIES = [
     tier: tier,
 
     life: 20 * getEnemyStatMultiplier(tier),
-    damage: 0 * getEnemyStatMultiplier(tier),
+    damage: 1 * getEnemyStatMultiplier(tier),
     attackSpeed: 1.2,
     attackRating: 12 * getEnemyStatMultiplier(tier),
     armor: 6 * getEnemyStatMultiplier(tier),
@@ -93,7 +93,7 @@ export const SWAMP_ENEMIES = [
     tier: tier,
 
     life: 22 * getEnemyStatMultiplier(tier),
-    damage: 0 * getEnemyStatMultiplier(tier),
+    damage: 1.2 * getEnemyStatMultiplier(tier),
     attackSpeed: 0.9,
     attackRating: 10 * getEnemyStatMultiplier(tier),
     armor: 7 * getEnemyStatMultiplier(tier),
@@ -102,7 +102,7 @@ export const SWAMP_ENEMIES = [
     xp: 9 * getEnemyStatMultiplier(tier),
     gold: 8 * getEnemyStatMultiplier(tier),
 
-    coldDamage: 5 * getEnemyStatMultiplier(tier),
+    coldDamage: 2 * getEnemyStatMultiplier(tier),
 
     fireResistance: 5,
     coldResistance: 25,

--- a/src/constants/enemies/obsidian_spire.js
+++ b/src/constants/enemies/obsidian_spire.js
@@ -42,7 +42,7 @@ export const OBSIDIAN_SPIRE_ENEMIES = [
     attackRating: 4.5 * getEnemyStatMultiplier(tier),
     armor: 15 * getEnemyStatMultiplier(tier),
 
-    earthDamage: 2.5 * getEnemyStatMultiplier(tier),
+    earthDamage: 2 * getEnemyStatMultiplier(tier),
 
     fireResistance: 25,
     coldResistance: 20,

--- a/src/constants/enemies/scorching_desert.js
+++ b/src/constants/enemies/scorching_desert.js
@@ -10,7 +10,7 @@ export const DESERT_ENEMIES = [
     tier: tier,
 
     life: 26 * getEnemyStatMultiplier(tier),
-    damage: 2 * getEnemyStatMultiplier(tier),
+    damage: 1.5 * getEnemyStatMultiplier(tier),
     attackRating: 12 * getEnemyStatMultiplier(tier),
     armor: 7 * getEnemyStatMultiplier(tier),
     evasion: 9 * getEnemyStatMultiplier(tier),
@@ -18,7 +18,7 @@ export const DESERT_ENEMIES = [
     xp: 9 * getEnemyStatMultiplier(tier),
     gold: 7 * getEnemyStatMultiplier(tier),
 
-    earthDamage: 3 * getEnemyStatMultiplier(tier),
+    earthDamage: 1.5 * getEnemyStatMultiplier(tier),
 
     fireResistance: 5,
     coldResistance: 15,
@@ -37,7 +37,7 @@ export const DESERT_ENEMIES = [
     tier: tier,
 
     life: 24 * getEnemyStatMultiplier(tier),
-    damage: 0 * getEnemyStatMultiplier(tier),
+    damage: 1 * getEnemyStatMultiplier(tier),
     attackSpeed: 1.1,
     attackRating: 12 * getEnemyStatMultiplier(tier),
     armor: 6 * getEnemyStatMultiplier(tier),
@@ -93,7 +93,7 @@ export const DESERT_ENEMIES = [
     tier: tier,
 
     life: 26 * getEnemyStatMultiplier(tier),
-    damage: 3 * getEnemyStatMultiplier(tier),
+    damage: 2 * getEnemyStatMultiplier(tier),
     attackSpeed: 1.1,
     attackRating: 12 * getEnemyStatMultiplier(tier),
     armor: 7 * getEnemyStatMultiplier(tier),
@@ -102,7 +102,7 @@ export const DESERT_ENEMIES = [
     xp: 9 * getEnemyStatMultiplier(tier),
     gold: 9 * getEnemyStatMultiplier(tier),
 
-    fireDamage: 3 * getEnemyStatMultiplier(tier),
+    fireDamage: 1.5 * getEnemyStatMultiplier(tier),
 
     fireResistance: 20,
     coldResistance: 5,

--- a/src/constants/enemies/skyrealm_peaks.js
+++ b/src/constants/enemies/skyrealm_peaks.js
@@ -38,7 +38,7 @@ export const SKYREALM_ENEMIES = [
     tier: tier,
 
     life: 28 * getEnemyStatMultiplier(tier),
-    damage: 4 * getEnemyStatMultiplier(tier),
+    damage: 2.5 * getEnemyStatMultiplier(tier),
     attackSpeed: 1.1,
     attackRating: 14 * getEnemyStatMultiplier(tier),
     armor: 7 * getEnemyStatMultiplier(tier),
@@ -75,8 +75,8 @@ export const SKYREALM_ENEMIES = [
     xp: 9 * getEnemyStatMultiplier(tier),
     gold: 9 * getEnemyStatMultiplier(tier),
 
-    airDamage: 4 * getEnemyStatMultiplier(tier),
-    earthDamage: 2 * getEnemyStatMultiplier(tier),
+    airDamage: 2.5 * getEnemyStatMultiplier(tier),
+    earthDamage: 0.5 * getEnemyStatMultiplier(tier),
 
     fireResistance: 5,
     coldResistance: 10,
@@ -95,7 +95,7 @@ export const SKYREALM_ENEMIES = [
     tier: tier,
 
     life: 30 * getEnemyStatMultiplier(tier),
-    damage: 4 * getEnemyStatMultiplier(tier),
+    damage: 2 * getEnemyStatMultiplier(tier),
     attackSpeed: 1.2,
     attackRating: 14 * getEnemyStatMultiplier(tier),
     armor: 15 * getEnemyStatMultiplier(tier),
@@ -104,7 +104,7 @@ export const SKYREALM_ENEMIES = [
     xp: 11 * getEnemyStatMultiplier(tier),
     gold: 13 * getEnemyStatMultiplier(tier),
 
-    airDamage: 2 * getEnemyStatMultiplier(tier),
+    airDamage: 1 * getEnemyStatMultiplier(tier),
 
     fireResistance: 5,
     coldResistance: 5,


### PR DESCRIPTION
## Summary
- keep enemy combined damage between 2.5 and 4
- tweak physical and elemental damage for all regions

## Testing
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888e094d3fc833194615f9b74464b35