### PR TITLE
feat: add reset stage skip option

### DIFF
--- a/src/crystalShop.js
+++ b/src/crystalShop.js
@@ -36,6 +36,13 @@ const CRYSTAL_UPGRADE_CONFIG = {
     multiple: true,
     bulkModal: true,
   },
+  resetStageSkip: {
+    label: 'Reset Stage Skip',
+    bonus: 'Unlocks option to stop skipping after a chosen stage',
+    bonusLabel: 'Unlocks reset stage skip option',
+    baseCost: 500,
+    oneTime: true,
+  },
   continuousPlay: {
     label: 'Continuous Play',
     bonus: 'Auto-continue after death',
@@ -460,6 +467,10 @@ export default class CrystalShop {
 
     if (stat === 'salvageMaterials' && options.salvageMaterialsEnabled) {
       inventory.setSalvageUpgradeMaterials(true);
+    }
+
+    if (stat === 'resetStageSkip') {
+      options.updateResetStageSkipOption();
     }
   }
 

--- a/src/game.js
+++ b/src/game.js
@@ -23,9 +23,13 @@ class Game {
   }
 
   incrementStage() {
-    // Use the stageSkip option if set, else fall back to crystalShop upgrade
-    let skipAmount = 1 + (options.stageSkip || 0);
-    this.stage += skipAmount;
+    // Use the stageSkip option unless resetStageSkip threshold is reached
+    let stageSkip = options.stageSkip || 0;
+    const resetAt = options.resetStageSkip || 0;
+    if (stageSkip > 0 && resetAt > 0 && this.stage >= resetAt) {
+      stageSkip = 0;
+    }
+    this.stage += 1 + stageSkip;
 
     const region = getCurrentRegion();
     const tier = region.tier || 1;

--- a/src/options.js
+++ b/src/options.js
@@ -21,6 +21,8 @@ export class Options {
     this.resetRequired = data.resetRequired ?? null;
     // Add stageSkip option, default to 0
     this.stageSkip = data.stageSkip || 0;
+    // Add resetStageSkip option, default to 0 (disabled)
+    this.resetStageSkip = data.resetStageSkip || 0;
     // Add soundVolume option, default to 0
     this.soundVolume = typeof data.soundVolume === 'number' ? data.soundVolume : 0;
     // Remember salvage preference across prestiges
@@ -96,6 +98,9 @@ export class Options {
 
     // --- Stage Skip Option ---
     container.appendChild(this._createStageSkipOption());
+
+    // --- Reset Stage Skip Option ---
+    container.appendChild(this._createResetStageSkipOption());
 
     // --- Changelog & Upcoming buttons row ---
     const changelogRow = document.createElement('div');
@@ -193,6 +198,62 @@ export class Options {
     if (isNaN(val) || val < 0) val = 0;
     if (val > max) val = max;
     this._stageSkipInput.value = val;
+  }
+
+  _createResetStageSkipOption() {
+    const purchased = !!crystalShop.crystalUpgrades?.resetStageSkip;
+    const value = this.resetStageSkip || 0;
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'option-row';
+    wrapper.innerHTML = html`
+      <label for="reset-stage-skip-input" class="reset-stage-skip-label">Reset Stage Skip At:</label>
+      <input
+        type="number"
+        id="reset-stage-skip-input"
+        class="reset-stage-skip-input"
+        min="0"
+        value="${value}"
+        title="${purchased ? 'Stage at which stage skip resets' : 'Purchase in crystal shop to enable'}"
+        ${purchased ? '' : 'disabled'}
+      />
+      <button class="apply-btn" type="button" ${purchased ? '' : 'disabled'}>Apply</button>
+    `;
+
+    const input = wrapper.querySelector('input');
+    const applyBtn = wrapper.querySelector('button');
+
+    this._resetStageSkipInput = input;
+    this._resetStageSkipWrapper = wrapper;
+
+    input.addEventListener('input', () => {
+      let val = parseInt(input.value, 10);
+      if (isNaN(val) || val < 0) val = 0;
+      input.value = val;
+    });
+
+    applyBtn.onclick = () => {
+      let val = parseInt(input.value, 10);
+      if (isNaN(val) || val < 0) val = 0;
+      this.resetStageSkip = val;
+      dataManager.saveGame();
+      showToast('Reset stage skip option applied!', 'success');
+    };
+
+    this.updateResetStageSkipOption();
+
+    return wrapper;
+  }
+
+  updateResetStageSkipOption() {
+    if (!this._resetStageSkipInput) return;
+    const purchased = !!crystalShop.crystalUpgrades?.resetStageSkip;
+    this._resetStageSkipInput.disabled = !purchased;
+    this._resetStageSkipInput.title = purchased
+      ? 'Stage at which stage skip resets'
+      : 'Purchase in crystal shop to enable';
+    const btn = this._resetStageSkipWrapper?.querySelector('button');
+    if (btn) btn.disabled = !purchased;
   }
 
   /**


### PR DESCRIPTION
## Summary
- add reset stage skip option to set a stage threshold where skipping stops
- offer reset stage skip upgrade in crystal shop for 500 crystals
- prevent stage skipping beyond selected stage
- remove changelog entry referencing this feature

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fdcda79188331b7ad66ba0a85e38c