### PR TITLE
Bugfix/decimal values

### DIFF
--- a/src/constants/stats/miscStats.js
+++ b/src/constants/stats/miscStats.js
@@ -231,16 +231,16 @@ export const MISC_STATS = {
   // ITEM QUANTITY
   itemQuantityPercent: {
     base: 0,
-    decimalPlaces: 2,
     item: { min: 4, max: 13, limit: 100, scaling: (level) => miscScaling(level) },
+    decimalPlaces: 0,
     itemTags: ['misc', 'jewelry', 'gloves', 'belt', 'amulet'],
     showInUI: true,
   },
   // ITEM RARITY
   itemRarityPercent: {
     base: 0,
-    decimalPlaces: 2,
     item: { min: 4, max: 13, limit: 100, scaling: (level) => miscScaling(level) },
+    decimalPlaces: 0,
     itemTags: ['misc', 'jewelry', 'gloves', 'belt', 'amulet'],
     showInUI: true,
   },

--- a/src/constants/stats/miscStats.js
+++ b/src/constants/stats/miscStats.js
@@ -231,17 +231,17 @@ export const MISC_STATS = {
   // ITEM QUANTITY
   itemQuantityPercent: {
     base: 0,
-    decimalPlaces: 0,
+    decimalPlaces: 2,
     item: { min: 4, max: 13, limit: 100, scaling: (level) => miscScaling(level) },
-    itemTags: ['misc', 'jewelry', 'gloves'],
+    itemTags: ['misc', 'jewelry', 'gloves', 'belt', 'amulet'],
     showInUI: true,
   },
   // ITEM RARITY
   itemRarityPercent: {
     base: 0,
-    decimalPlaces: 0,
+    decimalPlaces: 2,
     item: { min: 4, max: 13, limit: 100, scaling: (level) => miscScaling(level) },
-    itemTags: ['misc', 'jewelry', 'gloves'],
+    itemTags: ['misc', 'jewelry', 'gloves', 'belt', 'amulet'],
     showInUI: true,
   },
   // Only from materials. permanent skill points

--- a/src/hero.js
+++ b/src/hero.js
@@ -186,12 +186,6 @@ export default class Hero {
     );
     this.applyFinalCalculations(flatValues, percentBonuses);
 
-    // cycle through all stats to make all numbers have the correct decimal places
-    for (const stat in this.stats) {
-      const decimals = STATS[stat]?.decimalPlaces || 0;
-      this.stats[stat] = Number(this.stats[stat].toFixed(decimals));
-    }
-
     updatePlayerLife();
     updateStatsAndAttributesUI();
     dataManager.saveGame();


### PR DESCRIPTION
this.stats[stat] is the value in decimals, not in percentage. Example: 7% of rarity is 0.07 here, if you .toFixed(0), the result is 0... When it goes to calculate, rarity is now 0%


If an item has 7% and decimals is 1, here is 0.07.toFixed(1) = 0,1 then 0.1*100 = 10% rarity (or quantity or anything) this rounding is wrong