### PR TITLE
Adjust skill point allocation costs and rewards

### DIFF
--- a/src/constants/materials.js
+++ b/src/constants/materials.js
@@ -93,13 +93,13 @@ export const MATERIALS = {
     id: 'elixir',
     name: 'Elixir',
     icon: '🥤',
-    description: 'Grants 1 skill point.',
+    description: 'Grants 4 skill points.',
     dropChance: 2,
     sort: 300,
     exclusive: true, // only drops when region or enemy canDrop includes 'elixir'
     onUse: (hero, qty = 1) => {
-      hero.permaStats.skillPoints = hero.permaStats.skillPoints + 1 * qty;
-      skillTree.addSkillPoints(1 * qty);
+      hero.permaStats.skillPoints = hero.permaStats.skillPoints + 4 * qty;
+      skillTree.addSkillPoints(4 * qty);
     },
   },
   crystalized_rock: {

--- a/src/hero.js
+++ b/src/hero.js
@@ -99,7 +99,7 @@ export default class Hero {
     this.level += levels;
     this.statPoints += STATS_ON_LEVEL_UP * levels;
 
-    skillTree.addSkillPoints(levels); // Add 1 skill point per level
+    skillTree.addSkillPoints(levels * 3); // Add 3 skill points per level
 
     this.recalculateFromAttributes();
     createCombatText(`LEVEL UP! (${this.level})`);

--- a/src/skillTree.js
+++ b/src/skillTree.js
@@ -150,7 +150,7 @@ export default class SkillTree {
     if (!skill) return false;
 
     const currentLevel = this.skills[skillId]?.level || 0;
-    const cost = 1 + Math.floor(currentLevel / 50);
+    const cost = 3 + Math.floor(currentLevel / 50);
     // Prevent leveling skill above hero level
     if (currentLevel >= hero.level) {
       if (showWarning) {
@@ -183,7 +183,7 @@ export default class SkillTree {
       // Find how many levels until the next 50-level band
       const nextBand = 50 - (level % 50);
       const bandLevels = Math.min(remaining, nextBand);
-      const bandCost = bandLevels * (1 + Math.floor(level / 50));
+      const bandCost = bandLevels * (3 + Math.floor(level / 50));
       cost += bandCost;
       level += bandLevels;
       remaining -= bandLevels;
@@ -201,7 +201,7 @@ export default class SkillTree {
 
     while (level < maxLevel && availableSP > 0) {
       const band = Math.floor(level / 50);
-      const bandCost = 1 + band;
+      const bandCost = 3 + band;
       // How many levels left in this band?
       const bandEnd = (band + 1) * 50;
       const levelsInBand = Math.min(bandEnd - level, maxLevel - level);
@@ -586,7 +586,7 @@ export default class SkillTree {
     if (container) container.innerHTML = '';
 
     // Refund all skill points
-    this.skillPoints = hero.level - 1 + hero.permaStats.skillPoints;
+    this.skillPoints = (hero.level - 1) * 3 + hero.permaStats.skillPoints;
     this.selectedPath = null;
     this.skills = {};
     this.autoCastSettings = {};


### PR DESCRIPTION
## Summary
- Increase skill allocation cost to 3 skill points, rising by 1 after level 50
- Award 3 skill points per hero level and grant 4 points from elixir materials

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689709dc889c83318361de99c426fb20