### PR TITLE
Apply armor-like scaling to resistances and display reduction

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -45,12 +45,24 @@ export function enemyAttack(currentTime) {
         const physicalDamageRaw = game.currentEnemy.damage;
         const armorReduction = calculateArmorReduction(hero.stats.armor, physicalDamageRaw) / 100;
         const physicalDamage = Math.floor(physicalDamageRaw * (1 - armorReduction));
-        const fire = game.currentEnemy.fireDamage * (1 - hero.stats.fireResistance / 100);
-        const cold = game.currentEnemy.coldDamage * (1 - hero.stats.coldResistance / 100);
-        const air = game.currentEnemy.airDamage * (1 - hero.stats.airResistance / 100);
-        const earth = game.currentEnemy.earthDamage * (1 - hero.stats.earthResistance / 100);
-        const lightning = game.currentEnemy.lightningDamage * (1 - hero.stats.lightningResistance / 100);
-        const water = game.currentEnemy.waterDamage * (1 - hero.stats.waterResistance / 100);
+
+        const fireReduction = calculateResistanceReduction(hero.stats.fireResistance, game.currentEnemy.fireDamage) / 100;
+        const fire = game.currentEnemy.fireDamage * (1 - fireReduction);
+
+        const coldReduction = calculateResistanceReduction(hero.stats.coldResistance, game.currentEnemy.coldDamage) / 100;
+        const cold = game.currentEnemy.coldDamage * (1 - coldReduction);
+
+        const airReduction = calculateResistanceReduction(hero.stats.airResistance, game.currentEnemy.airDamage) / 100;
+        const air = game.currentEnemy.airDamage * (1 - airReduction);
+
+        const earthReduction = calculateResistanceReduction(hero.stats.earthResistance, game.currentEnemy.earthDamage) / 100;
+        const earth = game.currentEnemy.earthDamage * (1 - earthReduction);
+
+        const lightningReduction = calculateResistanceReduction(hero.stats.lightningResistance, game.currentEnemy.lightningDamage) / 100;
+        const lightning = game.currentEnemy.lightningDamage * (1 - lightningReduction);
+
+        const waterReduction = calculateResistanceReduction(hero.stats.waterResistance, game.currentEnemy.waterDamage) / 100;
+        const water = game.currentEnemy.waterDamage * (1 - waterReduction);
 
         let totalDamage = physicalDamage + fire + cold + air + earth + lightning + water;
 
@@ -321,6 +333,12 @@ export function calculateEvasionChance(evasion, attackRating, cap = 0.9) {
 export function calculateArmorReduction(armor, damage, cap = 0.9) {
   if (damage <= 0) return 0;
   const reduction = armor / (armor + 10 * damage);
+  return Math.max(0, Math.min(reduction, cap)) * 100;
+}
+
+export function calculateResistanceReduction(resistance, damage, cap = 0.75) {
+  if (damage <= 0) return 0;
+  const reduction = resistance / (resistance + 10 * damage);
   return Math.max(0, Math.min(reduction, cap)) * 100;
 }
 

--- a/src/constants/stats/attributes.js
+++ b/src/constants/stats/attributes.js
@@ -212,6 +212,6 @@ export const ATTRIBUTE_TOOLTIPS = {
     ${ELEMENTS.water.icon} Effective against water enemies.
   `,
   getElementalResistanceTooltip: () => html`
-    <strong>Elemental Resistance. Reduces elemental damage taken from enemies by a %.</strong>
+    <strong>Elemental Resistance. Reduces elemental damage taken from enemies based on your resistance and the enemy's damage.</strong>
   `,
 };

--- a/src/hero.js
+++ b/src/hero.js
@@ -1,6 +1,6 @@
 import { initializeSkillTreeStructure, updatePlayerLife, updateTabIndicators } from './ui/ui.js';
 import { game, inventory, training, skillTree, statistics, soulShop, dataManager } from './globals.js';
-import { calculateArmorReduction, createCombatText, createDamageNumber } from './combat.js';
+import { calculateArmorReduction, calculateResistanceReduction, createCombatText, createDamageNumber } from './combat.js';
 import { handleSavedData } from './functions.js';
 import { getCurrentRegion, updateRegionUI } from './region.js';
 import { STATS } from './constants/stats/stats.js';
@@ -426,19 +426,12 @@ export default class Hero {
 
     let allRes = this.stats.allResistance || 0;
 
-    this.stats.fireResistance = Math.min(this.stats.fireResistance + allRes, 75);
-    this.stats.coldResistance = Math.min(this.stats.coldResistance + allRes, 75);
-    this.stats.airResistance = Math.min(this.stats.airResistance + allRes, 75);
-    this.stats.earthResistance = Math.min(this.stats.earthResistance + allRes, 75);
-    this.stats.lightningResistance = Math.min(this.stats.lightningResistance + allRes, 75);
-    this.stats.waterResistance = Math.min(this.stats.waterResistance + allRes, 75);
-
-    if (this.stats.fireResistance < 0) this.stats.fireResistance = 0;
-    if (this.stats.coldResistance < 0) this.stats.coldResistance = 0;
-    if (this.stats.airResistance < 0) this.stats.airResistance = 0;
-    if (this.stats.earthResistance < 0) this.stats.earthResistance = 0;
-    if (this.stats.lightningResistance < 0) this.stats.lightningResistance = 0;
-    if (this.stats.waterResistance < 0) this.stats.waterResistance = 0;
+    this.stats.fireResistance = Math.max(this.stats.fireResistance + allRes, 0);
+    this.stats.coldResistance = Math.max(this.stats.coldResistance + allRes, 0);
+    this.stats.airResistance = Math.max(this.stats.airResistance + allRes, 0);
+    this.stats.earthResistance = Math.max(this.stats.earthResistance + allRes, 0);
+    this.stats.lightningResistance = Math.max(this.stats.lightningResistance + allRes, 0);
+    this.stats.waterResistance = Math.max(this.stats.waterResistance + allRes, 0);
 
     this.stats.manaRegen += this.stats.manaRegenOfTotalPercent * this.stats.mana;
     this.stats.lifeRegen += this.stats.lifeRegenOfTotalPercent * this.stats.life;
@@ -617,35 +610,53 @@ export default class Hero {
 
     const reducedBreakdown = {
       physical: breakdown.physical * (1 - armorReduction),
-      fire: breakdown.fire * (1 - getEffectiveResistance.call(this,
-        enemy.baseData.fireResistance,
-        this.stats.firePenetration,
-        this.stats.firePenetrationPercent,
+      fire: breakdown.fire * (1 - calculateResistanceReduction(
+        getEffectiveResistance.call(this,
+          enemy.baseData.fireResistance,
+          this.stats.firePenetration,
+          this.stats.firePenetrationPercent,
+        ),
+        breakdown.fire,
       ) / 100),
-      cold: breakdown.cold * (1 - getEffectiveResistance.call(this,
-        enemy.baseData.coldResistance,
-        this.stats.coldPenetration,
-        this.stats.coldPenetrationPercent,
+      cold: breakdown.cold * (1 - calculateResistanceReduction(
+        getEffectiveResistance.call(this,
+          enemy.baseData.coldResistance,
+          this.stats.coldPenetration,
+          this.stats.coldPenetrationPercent,
+        ),
+        breakdown.cold,
       ) / 100),
-      air: breakdown.air * (1 - getEffectiveResistance.call(this,
-        enemy.baseData.airResistance,
-        this.stats.airPenetration,
-        this.stats.airPenetrationPercent,
+      air: breakdown.air * (1 - calculateResistanceReduction(
+        getEffectiveResistance.call(this,
+          enemy.baseData.airResistance,
+          this.stats.airPenetration,
+          this.stats.airPenetrationPercent,
+        ),
+        breakdown.air,
       ) / 100),
-      earth: breakdown.earth * (1 - getEffectiveResistance.call(this,
-        enemy.baseData.earthResistance,
-        this.stats.earthPenetration,
-        this.stats.earthPenetrationPercent,
+      earth: breakdown.earth * (1 - calculateResistanceReduction(
+        getEffectiveResistance.call(this,
+          enemy.baseData.earthResistance,
+          this.stats.earthPenetration,
+          this.stats.earthPenetrationPercent,
+        ),
+        breakdown.earth,
       ) / 100),
-      lightning: breakdown.lightning * (1 - getEffectiveResistance.call(this,
-        enemy.baseData.lightningResistance,
-        this.stats.lightningPenetration,
-        this.stats.lightningPenetrationPercent,
+      lightning: breakdown.lightning * (1 - calculateResistanceReduction(
+        getEffectiveResistance.call(this,
+          enemy.baseData.lightningResistance,
+          this.stats.lightningPenetration,
+          this.stats.lightningPenetrationPercent,
+        ),
+        breakdown.lightning,
       ) / 100),
-      water: breakdown.water * (1 - getEffectiveResistance.call(this,
-        enemy.baseData.waterResistance,
-        this.stats.waterPenetration,
-        this.stats.waterPenetrationPercent,
+      water: breakdown.water * (1 - calculateResistanceReduction(
+        getEffectiveResistance.call(this,
+          enemy.baseData.waterResistance,
+          this.stats.waterPenetration,
+          this.stats.waterPenetrationPercent,
+        ),
+        breakdown.water,
       ) / 100),
     };
 

--- a/src/ui/statsAndAttributesUi.js
+++ b/src/ui/statsAndAttributesUi.js
@@ -7,7 +7,7 @@ import { MISC_STATS } from '../constants/stats/miscStats.js';
 import { formatStatName } from '../ui/ui.js';
 import { ATTRIBUTE_TOOLTIPS, ATTRIBUTES } from '../constants/stats/attributes.js';
 import { ELEMENTS } from '../constants/common.js';
-import { calculateArmorReduction, calculateEvasionChance, calculateHitChance } from '../combat.js';
+import { calculateArmorReduction, calculateEvasionChance, calculateHitChance, calculateResistanceReduction } from '../combat.js';
 
 const html = String.raw;
 
@@ -368,6 +368,25 @@ export function updateStatsAndAttributesUI() {
       const reduction = calculateArmorReduction(hero.stats.armor, game.currentEnemy.damage);
       armorEl.appendChild(document.createTextNode(` (${reduction.toFixed(2)}%)`));
     }
+
+    // Add elemental resistance reduction percentages
+    const resistanceMap = [
+      ['fireResistance', 'fireDamage'],
+      ['coldResistance', 'coldDamage'],
+      ['airResistance', 'airDamage'],
+      ['earthResistance', 'earthDamage'],
+      ['lightningResistance', 'lightningDamage'],
+      ['waterResistance', 'waterDamage'],
+    ];
+    resistanceMap.forEach(([resKey, dmgKey]) => {
+      const el = document.getElementById(`${resKey}-value`);
+      if (el) {
+        const value = formatNumber(hero.stats[resKey].toFixed(STATS[resKey].decimalPlaces || 0));
+        el.textContent = value;
+        const reduction = calculateResistanceReduction(hero.stats[resKey], game.currentEnemy[dmgKey]);
+        el.appendChild(document.createTextNode(` (${reduction.toFixed(2)}%)`));
+      }
+    });
 
     // add evasion reduction percentage to evasion
     const evasionEl = document.getElementById('evasion-value');

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -5,7 +5,7 @@ import { updateStatsAndAttributesUI } from './statsAndAttributesUi.js';
 import { TabIndicatorManager } from './tabIndicatorManager.js';
 import { selectBoss, updateBossUI } from './bossUi.js';
 import { ELEMENTS } from '../constants/common.js';
-import { calculateArmorReduction, calculateEvasionChance, calculateHitChance } from '../combat.js';
+import { calculateArmorReduction, calculateEvasionChance, calculateHitChance, calculateResistanceReduction } from '../combat.js';
 export {
   initializeSkillTreeUI,
   initializeSkillTreeStructure,
@@ -223,17 +223,35 @@ export function updateEnemyStats() {
   const atkSpeed = document.getElementById('enemy-attack-speed-value');
   if (atkSpeed) atkSpeed.textContent = formatNumber((enemy.attackSpeed || 0).toFixed(2));
   const fireRes = document.getElementById('enemy-fire-resistance-value');
-  if (fireRes) fireRes.textContent = formatNumber(Math.floor(enemy.fireResistance || 0));
+  if (fireRes) {
+    const reduction = calculateResistanceReduction(enemy.fireResistance, hero.stats.fireDamage);
+    fireRes.textContent = `${formatNumber(Math.floor(enemy.fireResistance || 0))} (${Math.floor(reduction)}%)`;
+  }
   const coldRes = document.getElementById('enemy-cold-resistance-value');
-  if (coldRes) coldRes.textContent = formatNumber(Math.floor(enemy.coldResistance || 0));
+  if (coldRes) {
+    const reduction = calculateResistanceReduction(enemy.coldResistance, hero.stats.coldDamage);
+    coldRes.textContent = `${formatNumber(Math.floor(enemy.coldResistance || 0))} (${Math.floor(reduction)}%)`;
+  }
   const airRes = document.getElementById('enemy-air-resistance-value');
-  if (airRes) airRes.textContent = formatNumber(Math.floor(enemy.airResistance || 0));
+  if (airRes) {
+    const reduction = calculateResistanceReduction(enemy.airResistance, hero.stats.airDamage);
+    airRes.textContent = `${formatNumber(Math.floor(enemy.airResistance || 0))} (${Math.floor(reduction)}%)`;
+  }
   const earthRes = document.getElementById('enemy-earth-resistance-value');
-  if (earthRes) earthRes.textContent = formatNumber(Math.floor(enemy.earthResistance || 0));
+  if (earthRes) {
+    const reduction = calculateResistanceReduction(enemy.earthResistance, hero.stats.earthDamage);
+    earthRes.textContent = `${formatNumber(Math.floor(enemy.earthResistance || 0))} (${Math.floor(reduction)}%)`;
+  }
   const lightningRes = document.getElementById('enemy-lightning-resistance-value');
-  if (lightningRes) lightningRes.textContent = formatNumber(Math.floor(enemy.lightningResistance || 0));
+  if (lightningRes) {
+    const reduction = calculateResistanceReduction(enemy.lightningResistance, hero.stats.lightningDamage);
+    lightningRes.textContent = `${formatNumber(Math.floor(enemy.lightningResistance || 0))} (${Math.floor(reduction)}%)`;
+  }
   const waterRes = document.getElementById('enemy-water-resistance-value');
-  if (waterRes) waterRes.textContent = formatNumber(Math.floor(enemy.waterResistance || 0));
+  if (waterRes) {
+    const reduction = calculateResistanceReduction(enemy.waterResistance, hero.stats.waterDamage);
+    waterRes.textContent = `${formatNumber(Math.floor(enemy.waterResistance || 0))} (${Math.floor(reduction)}%)`;
+  }
 
   setEnemyName();
   if (game.fightMode === 'explore') {


### PR DESCRIPTION
## Summary
- Introduce `calculateResistanceReduction` using armor-style scaling for elemental damage.
- Remove resistance caps and apply new formula across combat and damage calculations.
- Show resistance-based reduction percentages in hero and enemy UI, and clarify tooltips.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68973cbd6a58833196e6694a89c6ced0