### PR TITLE
Add Ascension system with upgradeable bonuses

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="/src/css/crystalShop.css" />
     <link rel="stylesheet" href="/src/css/soulShop.css" />
     <link rel="stylesheet" href="/src/css/prestige.css" />
+    <link rel="stylesheet" href="/src/css/ascension.css" />
     <link rel="stylesheet" href="/src/css/inventory.css" />
     <link rel="stylesheet" href="/src/css/skillTree.css" />
     <link rel="stylesheet" href="/src/css/statistics.css" />
@@ -69,6 +70,7 @@
                 <button class="tab-btn" data-tab="options">Options</button>
                 <button class="tab-btn" data-tab="buildings">Buildings</button>
                 <button class="tab-btn" data-tab="prestige">Prestige</button>
+                <button class="tab-btn" data-tab="ascension">Ascension</button>
                 <!-- <button class="tab-btn" data-tab="leaderboard">Leaderboard</button> -->
             </div>
         </div>
@@ -82,6 +84,7 @@
                 <div id="skilltree" class="tab-panel"></div>
                 <div id="soulShop" class="tab-panel"></div>
                 <div id="prestige" class="tab-panel"></div>
+                <div id="ascension" class="tab-panel"></div>
                 <div id="statistics" class="tab-panel"></div>
                 <div id="options" class="tab-panel"></div>
                 <div id="quests" class="tab-panel"></div>

--- a/src/ascension.js
+++ b/src/ascension.js
@@ -1,0 +1,101 @@
+import { hero, prestige, options, dataManager, setGlobals } from './globals.js';
+
+export const ASCENSION_UPGRADES = {
+  strengthDamage: {
+    label: 'Strength → Damage %',
+    description: 'Increase damage gained from Strength by 10% per level',
+    bonus: 0.10,
+  },
+  vitalityLife: {
+    label: 'Vitality → Life %',
+    description: 'Increase life gained from Vitality by 10% per level',
+    bonus: 0.10,
+  },
+  bonusExperience: {
+    label: 'Bonus Experience %',
+    description: 'Increase experience gained by 50% per level',
+    bonus: 0.50,
+    stat: 'bonusExperiencePercent',
+  },
+  bonusGold: {
+    label: 'Bonus Gold %',
+    description: 'Increase gold gained by 50% per level',
+    bonus: 0.50,
+    stat: 'bonusGoldPercent',
+  },
+};
+
+export default class Ascension {
+  constructor(savedData = null) {
+    this.points = 0;
+    this.upgrades = {};
+    this.appliedBonuses = {};
+    Object.assign(this, savedData);
+  }
+
+  getAvailablePoints() {
+    return this.points;
+  }
+
+  purchaseUpgrade(key) {
+    if (this.points <= 0) return false;
+    if (!ASCENSION_UPGRADES[key]) return false;
+    this.upgrades[key] = (this.upgrades[key] || 0) + 1;
+    this.points -= 1;
+    this.applyBonuses();
+    dataManager.saveGame();
+    return true;
+  }
+
+  getUpgradeLevel(key) {
+    return this.upgrades[key] || 0;
+  }
+
+  getAttributeMultiplier(attr, stat) {
+    if (attr === 'strength' && stat === 'damage') {
+      return 1 + (this.upgrades.strengthDamage || 0) * ASCENSION_UPGRADES.strengthDamage.bonus;
+    }
+    if (attr === 'vitality' && stat === 'life') {
+      return 1 + (this.upgrades.vitalityLife || 0) * ASCENSION_UPGRADES.vitalityLife.bonus;
+    }
+    return 1;
+  }
+
+  applyBonuses() {
+    // Remove previously applied bonuses
+    Object.entries(this.appliedBonuses).forEach(([stat, val]) => {
+      hero.permaStats[stat] = (hero.permaStats[stat] || 0) - val;
+    });
+    const newBonuses = {};
+    if (this.upgrades.bonusExperience) {
+      newBonuses.bonusExperiencePercent = this.upgrades.bonusExperience * ASCENSION_UPGRADES.bonusExperience.bonus;
+    }
+    if (this.upgrades.bonusGold) {
+      newBonuses.bonusGoldPercent = this.upgrades.bonusGold * ASCENSION_UPGRADES.bonusGold.bonus;
+    }
+    Object.entries(newBonuses).forEach(([stat, val]) => {
+      hero.permaStats[stat] = (hero.permaStats[stat] || 0) + val;
+    });
+    this.appliedBonuses = newBonuses;
+    hero.recalculateFromAttributes();
+  }
+
+  async ascend() {
+    const gained = prestige.prestigeCount;
+    if (gained <= 0) return;
+    this.points += gained;
+    const ascensionData = JSON.parse(JSON.stringify({ points: this.points, upgrades: this.upgrades }));
+    const showEnemyStats = options.showEnemyStats;
+    const resetRequired = options.resetRequired;
+    const salvageMaterialsEnabled = options.salvageMaterialsEnabled;
+
+    await setGlobals({ reset: true, ascensionData });
+
+    options.showEnemyStats = showEnemyStats;
+    options.resetRequired = resetRequired;
+    options.salvageMaterialsEnabled = salvageMaterialsEnabled;
+
+    dataManager.saveGame();
+    window.location.reload();
+  }
+}

--- a/src/css/ascension.css
+++ b/src/css/ascension.css
@@ -1,0 +1,24 @@
+.ascension-container {
+  padding: 1rem;
+}
+.ascension-header {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+.ascension-upgrades-list {
+  list-style: none;
+  padding: 0;
+}
+.ascension-upgrades-list li {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+.ascension-upgrades-list .upgrade-label {
+  flex: 1;
+}
+.ascension-upgrade-btn.disabled {
+  opacity: 0.5;
+}

--- a/src/globals.js
+++ b/src/globals.js
@@ -11,6 +11,7 @@ import Statistics from './statistics.js';
 import Training from './training.js';
 import { BuildingManager } from './building.js';
 import Prestige from './prestige.js';
+import Ascension from './ascension.js';
 
 // Global singletons for the game
 export let game = null;
@@ -26,9 +27,10 @@ export let options = null;
 export let dataManager = null;
 export let buildings = null;
 export let prestige = null;
+export let ascension = null;
 
 // Setters for initialization in main.js
-export async function setGlobals({ cloud = false, reset = false } = {}) {
+export async function setGlobals({ cloud = false, reset = false, ascensionData = null } = {}) {
   // setup data manager. version not set yet
   const _dataManager = new DataManager();
   _dataManager.startSessionMonitor();
@@ -50,6 +52,7 @@ export async function setGlobals({ cloud = false, reset = false } = {}) {
   const _options = new Options(savedData?.options);
   const _buildings = await BuildingManager.create(savedData?.buildings);
   const _prestige = new Prestige(savedData?.prestige);
+  const _ascension = new Ascension(reset ? ascensionData : savedData?.ascension);
 
   game = _game;
   hero = _hero;
@@ -63,7 +66,13 @@ export async function setGlobals({ cloud = false, reset = false } = {}) {
   buildings = _buildings;
   options = _options;
   prestige = _prestige;
+  ascension = _ascension;
   dataManager = _dataManager;
+
+  // Apply ascension bonuses after hero is created
+  if (ascension) {
+    ascension.applyBonuses();
+  }
 
   // useful when loading from cloud
   dataManager.saveGame();
@@ -83,6 +92,7 @@ export function getGlobals() {
     buildings,
     options,
     prestige,
+    ascension,
     dataManager,
   };
 }

--- a/src/hero.js
+++ b/src/hero.js
@@ -1,5 +1,5 @@
 import { initializeSkillTreeStructure, updatePlayerLife, updateTabIndicators } from './ui/ui.js';
-import { game, inventory, training, skillTree, statistics, soulShop, dataManager } from './globals.js';
+import { game, inventory, training, skillTree, statistics, soulShop, dataManager, ascension } from './globals.js';
 import { calculateArmorReduction, calculateResistanceReduction, createCombatText, createDamageNumber } from './combat.js';
 import { handleSavedData } from './functions.js';
 import { getCurrentRegion, updateRegionUI } from './region.js';
@@ -265,7 +265,11 @@ export default class Hero {
         // Flat per-point bonus (e.g., damagePerPoint, lifePerPoint, etc.)
         const flatKey = stat + 'PerPoint';
         if (flatKey in attrEffects) {
-          flatBonus += (this.stats[attr] || 0) * attrEffects[flatKey];
+          let effect = attrEffects[flatKey];
+          if (ascension && typeof ascension.getAttributeMultiplier === 'function') {
+            effect *= ascension.getAttributeMultiplier(attr, stat);
+          }
+          flatBonus += (this.stats[attr] || 0) * effect;
         }
 
         // Percent per N points bonus (e.g., damagePercentPer, lifePercentPer, etc.)

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,7 @@ import { updateRegionUI } from './region.js';
 import { updateStatsAndAttributesUI } from './ui/statsAndAttributesUi.js';
 import { initializeBuildingsUI, renderPurchasedBuildings } from './ui/buildingUi.js';
 import { initializePrestigeUI } from './ui/prestigeUi.js';
+import { initializeAscensionUI } from './ui/ascensionUi.js';
 import Enemy from './enemy.js';
 import { setupLeaderboardTabLazyLoad } from './ui/leaderboardUi.js';
 import Boss from './boss.js';
@@ -58,6 +59,7 @@ window.log = console.log;
   initializeSkillTreeUI();
   initializeBuildingsUI();
   initializePrestigeUI();
+  initializeAscensionUI();
 
   updateResources();
   hero.recalculateFromAttributes();

--- a/src/ui/ascensionUi.js
+++ b/src/ui/ascensionUi.js
@@ -1,0 +1,67 @@
+import { ascension, prestige } from '../globals.js';
+import { ASCENSION_UPGRADES } from '../ascension.js';
+import { showToast } from './ui.js';
+
+const html = String.raw;
+
+export function initializeAscensionUI() {
+  const tab = document.getElementById('ascension');
+  if (!tab) return;
+
+  let container = tab.querySelector('.ascension-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.className = 'ascension-container';
+    tab.innerHTML = '';
+    tab.appendChild(container);
+  }
+
+  function render() {
+    const upgradesHtml = Object.entries(ASCENSION_UPGRADES)
+      .map(([key, cfg]) => {
+        const disabled = ascension.getAvailablePoints() <= 0 ? 'disabled' : '';
+        return html`
+          <li>
+            <span class="upgrade-label">${cfg.label} (Lvl ${ascension.getUpgradeLevel(key)})</span>
+            <button class="ascension-upgrade-btn" data-up="${key}" ${disabled}>Upgrade</button>
+          </li>
+        `;
+      })
+      .join('');
+
+    container.innerHTML = html`
+      <div class="ascension-header">
+        <button id="ascend-now-btn">Ascend Now</button>
+        <div>Ascension Points: <span id="ascension-points">${ascension.getAvailablePoints()}</span></div>
+      </div>
+      <ul class="ascension-upgrades-list">
+        ${upgradesHtml}
+      </ul>
+    `;
+
+    container.querySelectorAll('.ascension-upgrade-btn').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const key = btn.dataset.up;
+        const success = ascension.purchaseUpgrade(key);
+        if (!success) {
+          showToast('Not enough ascension points.');
+        }
+        render();
+      });
+    });
+
+    const ascendBtn = container.querySelector('#ascend-now-btn');
+    if (prestige.prestigeCount <= 0) {
+      ascendBtn.classList.add('disabled');
+    }
+    ascendBtn.addEventListener('click', () => {
+      if (prestige.prestigeCount <= 0) {
+        showToast('Prestige at least once to ascend.');
+        return;
+      }
+      ascension.ascend();
+    });
+  }
+
+  render();
+}


### PR DESCRIPTION
## Summary
- Introduce Ascension layer that converts prestige count into ascension points
- Allow spending points on powerful upgrades (e.g., Strength→Damage, Vitality→Life, XP and Gold boosts)
- Add Ascension tab and wiring so bonuses apply to hero stats

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68978ba6e35c8331a7f7dee278218c51